### PR TITLE
Add official firmware Download mode and harden flash/connect

### DIFF
--- a/.cursor/rules/reinstall-after-extension-changes.mdc
+++ b/.cursor/rules/reinstall-after-extension-changes.mdc
@@ -1,0 +1,35 @@
+---
+description: Auto-reinstall mpftp into Cursor after extension changes that need a reload
+alwaysApply: true
+---
+
+# Reinstall after extension changes
+
+Whenever you change code that the **installed** Cursor extension loads (not only the workspace tree), **reinstall before ending the turn** — do not wait for Brad to ask.
+
+## Requires reinstall
+
+- TypeScript under `src/` (compiled to `out/`)
+- `package.json` contribution points / activation
+- Webview assets: `media/**` (ftp.js, firmware.js, CSS, HTML)
+- Sidecar / engine used by the extension: `python/sidecar.py`, `python/firmware_engine.py`, `python/firmware_download.py`, and other Python the extension spawns from the install dir
+- `resources/**`, extension packaging scripts that affect the installed copy
+
+## Does not require reinstall
+
+- Docs-only, plan files, tests that are never shipped in the VSIX
+- Pure CLI scripts Brad runs from the repo checkout (unless the extension also ships/runs that same file from the install path)
+
+## How
+
+From the repo root:
+
+```bash
+./scripts/install-cursor-wsl.sh
+# and when packaging matters for the host install:
+npm run package && cursor --install-extension "$(ls -t *.vsix | head -1)" --force
+```
+
+Prefer `./scripts/install-cursor-wsl.sh` at minimum (compile + rsync into `~/.cursor-server/extensions/bdbarnett.mpftp-*`). Also force-install the VSIX when that is the path Brad has been using.
+
+Remind briefly that **Developer: Reload Window** is still needed — the agent cannot reload the extension host from the CLI.

--- a/media/firmware.css
+++ b/media/firmware.css
@@ -64,10 +64,43 @@ body {
 
 .hdr-below {
   display: flex;
-  justify-content: space-between;
+  flex-direction: column;
+  align-items: stretch;
+  gap: 10px;
+}
+
+.source-row {
+  display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 10px;
   flex-wrap: wrap;
+}
+
+.seg {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.seg-btn {
+  appearance: none;
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  padding: 4px 14px;
+  font: inherit;
+  cursor: pointer;
+}
+
+.seg-btn:hover {
+  background: var(--hover);
+  color: var(--fg);
+}
+
+.seg-btn.active {
+  background: var(--accent);
+  color: var(--accent-fg);
 }
 
 .brand {
@@ -145,6 +178,10 @@ body {
   gap: 16px;
 }
 
+.grid > .step-span {
+  grid-column: 1 / -1;
+}
+
 @media (max-width: 720px) {
   .grid {
     grid-template-columns: 1fr;
@@ -172,6 +209,10 @@ body {
   align-items: center;
   gap: 10px;
   margin-bottom: 12px;
+}
+
+.step-head .step-trailing {
+  margin-left: auto;
 }
 
 .step-num {
@@ -402,7 +443,24 @@ body {
   padding: 12px;
 }
 
-/* Modules */
+/* Modules (sub-card inside Select / Build) */
+.sub-card {
+  margin-top: 12px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: calc(var(--radius) - 2px);
+  background: color-mix(in srgb, var(--card-bg) 70%, var(--bg));
+}
+
+.sub-card-title {
+  font-size: 12px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 8px;
+}
+
 .discovered-from {
   display: flex;
   align-items: baseline;
@@ -570,6 +628,30 @@ body {
   width: auto;
 }
 
+.field-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin: 8px 0;
+}
+
+.field-row label {
+  font-size: 12.5px;
+  color: var(--muted);
+  min-width: 72px;
+}
+
+.field-row select {
+  flex: 1;
+  min-width: 0;
+  background: var(--input-bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 5px 8px;
+  font: inherit;
+}
+
 .offset-row {
   display: flex;
   align-items: center;
@@ -658,7 +740,7 @@ body {
   color: var(--muted);
 }
 
-/* Device Info */
+/* Detect (step 1) — was Device Info */
 .device-card {
   margin-bottom: 16px;
 }

--- a/media/firmware.js
+++ b/media/firmware.js
@@ -10,7 +10,16 @@
     cmods: { modules: [], hasAggregator: false, hasManifest: false },
     flashers: {},
     selection: { port: "", board: "", variant: "" },
-    prefs: { reconnectAfterFlash: false, alsoFlashAfterBuild: false, device: "" },
+    prefs: {
+      reconnectAfterFlash: false,
+      alsoFlashAfterBuild: false,
+      device: "",
+      firmwareSource: "build",
+      downloadVersion: "",
+      downloadPreview: false,
+    },
+    downloadVersions: [],
+    downloadFamily: "",
     connectedDevice: "",
     devices: [],
     detect: null,
@@ -19,8 +28,8 @@
     artifact: { ready: false },
     flashOffset: "",
     flashBaud: "460800",
-    flashBefore: "default_reset",
-    flashAfter: "hard_reset",
+    flashBefore: "default-reset",
+    flashAfter: "hard-reset",
     flashErase: false,
     flashStatus: null,
     flashing: false,
@@ -30,6 +39,10 @@
     busy: false,
     cleanBuild: false,
   };
+
+  function isDownloadMode() {
+    return model.prefs.firmwareSource === "download";
+  }
 
   const $ = (sel, root) => (root || document).querySelector(sel);
   const el = (tag, cls, txt) => {
@@ -63,18 +76,19 @@
 
     app.appendChild(renderHeader());
 
-    if (!model.micropython) {
-      app.appendChild(renderNoMp());
-      app.appendChild(renderLog());
-      return;
-    }
-
-    app.appendChild(renderModules());
-    app.appendChild(renderDeviceInfo());
-
     const grid = el("div", "grid");
+    const detect = renderDetect();
+    detect.classList.add("step-span");
+    grid.appendChild(detect);
+    grid.appendChild(renderSource());
     grid.appendChild(renderTarget());
-    grid.appendChild(renderBuild());
+    if (isDownloadMode()) {
+      grid.appendChild(renderDownload());
+    } else if (model.micropython) {
+      grid.appendChild(renderBuild());
+    } else {
+      grid.appendChild(renderBuildNeedsMp());
+    }
     grid.appendChild(renderFlash());
     app.appendChild(grid);
     app.appendChild(renderLog());
@@ -98,19 +112,12 @@
 
     const below = el("div", "hdr-below");
     below.appendChild(
-      el("p", "subtitle", "Build MicroPython once, then flash one or many boards.")
+      el(
+        "p",
+        "subtitle",
+        "Detect the board, choose Build or Download, pick a target, then build or download firmware and flash."
+      )
     );
-    const pathRow = el("div", "path-row");
-    pathRow.appendChild(el("span", "hdr-label", "MicroPython repo"));
-    const icon = el("i", "codicon codicon-repo");
-    pathRow.appendChild(icon);
-    const pathText = el("span", "path-text", model.micropython || "No MicroPython found");
-    pathText.title = model.micropython || "";
-    pathRow.appendChild(pathText);
-    const change = el("button", "btn ghost sm", "Change…");
-    change.onclick = () => vscode.postMessage({ type: "changePath" });
-    pathRow.appendChild(change);
-    below.appendChild(pathRow);
     h.appendChild(below);
     return h;
   }
@@ -137,7 +144,23 @@
     return c;
   }
 
-  // Device Info — esptool-first Detect
+  function renderBuildNeedsMp() {
+    const card = el("section", "card step");
+    card.appendChild(stepHead("4", "Build", "no checkout"));
+    card.appendChild(
+      el(
+        "p",
+        "muted",
+        "Select a MicroPython checkout to build, or switch Select to Download for official firmware."
+      )
+    );
+    const b = el("button", "btn primary", "Select MicroPython folder…");
+    b.onclick = () => vscode.postMessage({ type: "changePath" });
+    card.appendChild(b);
+    return card;
+  }
+
+  // Step 1 — Detect (esptool-first)
   function mpMachine(d) {
     const mp = (d && d.mp) || {};
     return mp.machine || mp.platform || "";
@@ -193,16 +216,17 @@
     return parts.join(" · ");
   }
 
-  function renderDeviceInfo() {
-    const card = el("section", "card device-card");
-    const head = el("div", "info-head");
-    head.appendChild(el("span", "step-title", "Device Info"));
+  function renderDetect() {
+    const card = el("section", "card step");
     const btn = el("button", "btn accent sm", model.detecting ? "Detecting…" : "Detect");
     btn.disabled = model.busy || model.detecting || model.flashing;
     btn.title = "Probe the selected device with esptool (bare board OK)";
     btn.onclick = () => vscode.postMessage({ type: "detect" });
-    head.appendChild(btn);
-    card.appendChild(head);
+    const chip = model.prefs.device
+      ? model.prefs.device +
+        (model.detect && model.detect.chip ? " · " + model.detect.chip : "")
+      : "no device";
+    card.appendChild(stepHead("1", "Detect", chip, btn));
 
     const ds = model.detectStatus;
     if (ds && ds.state === "failed") {
@@ -337,10 +361,10 @@
     return String(freq);
   }
 
-  // Step 1 — Target
+  // Step 3 — Target
   function renderTarget() {
     const card = el("section", "card step");
-    card.appendChild(stepHead("1", "Target", chipText()));
+    card.appendChild(stepHead("3", "Target", chipText()));
 
     const search = el("input", "search");
     search.placeholder = "Filter ports and boards…";
@@ -360,7 +384,64 @@
   function chipText() {
     const s = model.selection;
     if (!s.port) return "none selected";
+    // Download mode also has MP variants (e.g. ESP32_GENERIC_P4 / C6_WIFI).
     return [s.port, s.board || null, s.variant || "default"].filter(Boolean).join(" / ");
+  }
+
+  // Step 2 — Select Build or Download
+  function renderSource() {
+    const card = el("section", "card step");
+    const mode = isDownloadMode() ? "Download" : "Build";
+    card.appendChild(stepHead("2", "Select", mode));
+
+    const sourceRow = el("div", "source-row");
+    const seg = el("div", "seg");
+    for (const [id, label] of [
+      ["build", "Build"],
+      ["download", "Download"],
+    ]) {
+      const btn = el(
+        "button",
+        "seg-btn" + (model.prefs.firmwareSource === id ? " active" : ""),
+        label
+      );
+      btn.onclick = () => {
+        if (model.prefs.firmwareSource === id) return;
+        model.prefs.firmwareSource = id;
+        vscode.postMessage({ type: "setSource", source: id });
+        render();
+      };
+      seg.appendChild(btn);
+    }
+    sourceRow.appendChild(seg);
+    card.appendChild(sourceRow);
+
+    if (isDownloadMode()) {
+      card.appendChild(
+        el(
+          "p",
+          "muted sm",
+          "Official builds via Thonny’s catalog → micropython.org (no local checkout required)."
+        )
+      );
+    } else {
+      const pathRow = el("div", "path-row");
+      pathRow.appendChild(el("span", "hdr-label", "MicroPython repo"));
+      pathRow.appendChild(el("i", "codicon codicon-repo"));
+      const pathText = el(
+        "span",
+        "path-text",
+        model.micropython || "No MicroPython found"
+      );
+      pathText.title = model.micropython || "";
+      pathRow.appendChild(pathText);
+      const change = el("button", "btn ghost sm", "Change…");
+      change.onclick = () => vscode.postMessage({ type: "changePath" });
+      pathRow.appendChild(change);
+      card.appendChild(pathRow);
+      card.appendChild(renderModules());
+    }
+    return card;
   }
 
   function matches(text) {
@@ -439,7 +520,7 @@
       node.appendChild(kids);
       return node;
     }
-    return renderLeaf(port.port, b.board, "", b.board);
+    return renderLeaf(port.port, b.board, "", b.label || b.board);
   }
 
   function renderLeaf(port, board, variant, label) {
@@ -465,12 +546,12 @@
     render();
   }
 
-  // Modules — discovery only (not a numbered step). The C-module set is scanned
-  // from the workspace (parent of the MicroPython checkout); repoint via the
-  // header's Change… control.
+  // Modules — discovery sub-card inside Select when Build is chosen.
+  // Scanned from the workspace (parent of the MicroPython checkout); repoint
+  // via Select's Change… control.
   function renderModules() {
-    const card = el("section", "card step");
-    card.appendChild(stepHead("", "Modules", ""));
+    const card = el("div", "sub-card");
+    card.appendChild(el("div", "sub-card-title", "Modules"));
     const from = model.workspace || model.micropython;
     if (from) {
       const src = el("p", "discovered-from");
@@ -526,10 +607,98 @@
     return card;
   }
 
+  // Step 2 — Download (official firmware)
+  function renderDownload() {
+    const card = el("section", "card step");
+    card.appendChild(stepHead("4", "Download", chipText()));
+
+    const statusRow = el("div", "status-row");
+    statusRow.appendChild(phasePill());
+    card.appendChild(statusRow);
+
+    if (!model.selection.board) {
+      card.appendChild(
+        el("p", "muted", "Select a board in Target. Detect can suggest one from the chip.")
+      );
+      return card;
+    }
+
+    const verRow = el("div", "field-row");
+    verRow.appendChild(el("label", null, "Version"));
+    const sel = document.createElement("select");
+    const latest = document.createElement("option");
+    latest.value = "";
+    latest.textContent = "Latest release";
+    sel.appendChild(latest);
+    const prev = document.createElement("option");
+    prev.value = "__preview__";
+    prev.textContent = "Latest preview";
+    sel.appendChild(prev);
+    for (const d of model.downloadVersions || []) {
+      if (d.channel === "preview") continue;
+      const o = document.createElement("option");
+      o.value = d.version;
+      o.textContent = d.version;
+      sel.appendChild(o);
+    }
+    if (model.prefs.downloadPreview) {
+      sel.value = "__preview__";
+    } else {
+      sel.value = model.prefs.downloadVersion || "";
+    }
+    sel.onchange = () => {
+      if (sel.value === "__preview__") {
+        model.prefs.downloadPreview = true;
+        model.prefs.downloadVersion = "";
+        vscode.postMessage({ type: "setPref", key: "downloadPreview", value: true });
+      } else {
+        model.prefs.downloadPreview = false;
+        model.prefs.downloadVersion = sel.value;
+        vscode.postMessage({ type: "setPref", key: "downloadVersion", value: sel.value });
+      }
+    };
+    verRow.appendChild(sel);
+    card.appendChild(verRow);
+
+    if (model.artifact && model.artifact.ready) {
+      const info = el("div", "artifact");
+      info.appendChild(el("i", "codicon codicon-cloud-download"));
+      const details = el("div", "artifact-details");
+      const full = model.artifact.artifact || "";
+      const name = full.split(/[/\\]/).pop();
+      details.appendChild(el("div", "artifact-name", name));
+      const meta = [
+        model.artifact.version ? "v" + String(model.artifact.version).replace(/^v/, "") : "",
+        humanSize(model.artifact.size),
+        model.artifact.source === "local" ? "local file" : "cached",
+      ]
+        .filter(Boolean)
+        .join(" · ");
+      details.appendChild(el("div", "muted sm", meta));
+      info.appendChild(details);
+      card.appendChild(info);
+    } else {
+      card.appendChild(el("p", "muted", "Not downloaded yet for this selection."));
+    }
+
+    const actions = el("div", "actions");
+    const dl = el("button", "btn primary", model.busy ? "Working…" : "Download");
+    dl.disabled =
+      model.busy || model.detecting || model.flashing || !model.selection.board;
+    dl.onclick = () => vscode.postMessage({ type: "download" });
+    actions.appendChild(dl);
+    const browse = el("button", "btn ghost", "Browse local…");
+    browse.disabled = model.busy || model.flashing;
+    browse.onclick = () => vscode.postMessage({ type: "browseArtifact" });
+    actions.appendChild(browse);
+    card.appendChild(actions);
+    return card;
+  }
+
   // Step 2 — Build
   function renderBuild() {
     const card = el("section", "card step");
-    card.appendChild(stepHead("2", "Build", chipText()));
+    card.appendChild(stepHead("4", "Build", chipText()));
 
     const statusRow = el("div", "status-row");
     statusRow.appendChild(phasePill());
@@ -595,10 +764,10 @@
     return card;
   }
 
-  // Step 3 — Firmware (flash)
+  // Step 5 — Flash
   function renderFlash() {
     const card = el("section", "card step");
-    card.appendChild(stepHead("3", "Firmware", ""));
+    card.appendChild(stepHead("5", "Flash", ""));
 
     const fp = flashPill();
     if (fp) {
@@ -646,6 +815,7 @@
 
     const ready = model.artifact && model.artifact.ready;
     const needsDevice = port === "esp32" && !model.prefs.device;
+    // flash tip uses ready below
 
     // esp32 only: editable flash offset + baud, between the device row and Flash.
     if (port === "esp32") {
@@ -695,24 +865,24 @@
         selectRow(
           "Reset before",
           [
-            ["default_reset", "default_reset"],
-            ["no_reset", "no_reset"],
-            ["usb_reset", "usb_reset"],
+            ["default-reset", "default-reset"],
+            ["no-reset", "no-reset"],
+            ["usb-reset", "usb-reset"],
           ],
           model.flashBefore,
           (v) => {
             model.flashBefore = v;
           },
-          "esptool --before: how the chip enters the bootloader. Use no_reset when you've manually put the board in download mode."
+          "esptool --before: how the chip enters the bootloader. Use no-reset when you've manually put the board in download mode."
         )
       );
       opts.appendChild(
         selectRow(
           "Reset after",
           [
-            ["hard_reset", "hard_reset"],
-            ["soft_reset", "soft_reset"],
-            ["no_reset", "no_reset"],
+            ["hard-reset", "hard-reset"],
+            ["soft-reset", "soft-reset"],
+            ["no-reset", "no-reset"],
           ],
           model.flashAfter,
           (v) => {
@@ -743,8 +913,11 @@
     const flash = el("button", "btn accent", model.flashing ? "Flashing…" : "Flash");
     flash.disabled =
       model.busy || model.detecting || model.flashing || !ready || needsDevice;
-    if (!ready) flash.title = "Build this board first";
-    else if (needsDevice) flash.title = "Select a device";
+    if (!ready) {
+      flash.title = isDownloadMode()
+        ? "Download firmware first"
+        : "Build this board first";
+    } else if (needsDevice) flash.title = "Select a device";
     flash.onclick = () =>
       vscode.postMessage({
         type: "flash",
@@ -789,11 +962,15 @@
     return card;
   }
 
-  function stepHead(n, title, chip) {
+  function stepHead(n, title, chip, trailing) {
     const h = el("div", "step-head");
     if (n) h.appendChild(el("span", "step-num", n));
     h.appendChild(el("span", "step-title", title));
     if (chip) h.appendChild(el("span", "sel-chip", chip));
+    if (trailing) {
+      trailing.classList.add("step-trailing");
+      h.appendChild(trailing);
+    }
     return h;
   }
 
@@ -953,7 +1130,9 @@
           cmods: msg.cmods || {},
           flashers: msg.flashers || {},
           selection: msg.selection || model.selection,
-          prefs: msg.prefs || model.prefs,
+          prefs: Object.assign({}, model.prefs, msg.prefs || {}),
+          downloadVersions: msg.downloadVersions || [],
+          downloadFamily: msg.downloadFamily || "",
           connectedDevice: msg.connectedDevice || "",
           detect: msg.detect !== undefined ? msg.detect : model.detect,
           busy: msg.busy,
@@ -963,7 +1142,7 @@
       case "detectStatus":
         model.detectStatus = { state: msg.state, text: msg.text || "" };
         // Latch "detecting" on start; cleared by the later "detect" message so
-        // the Detect button stays disabled until Device Info is populated.
+        // the Detect button stays disabled until Detect results are populated.
         if (msg.state === "detecting") {
           model.detecting = true;
         }
@@ -983,6 +1162,17 @@
         // user edits it (empty === "use default").
         if (!model.flashOffset && model.artifact.flashOffset) {
           model.flashOffset = model.artifact.flashOffset;
+        }
+        render();
+        break;
+      case "flashOffsetDefault":
+        if (msg.flashOffset) {
+          // Always refresh from board.json when Target changes; user edits to
+          // the field are wiped on select (model.flashOffset = "").
+          model.flashOffset = String(msg.flashOffset);
+          if (model.artifact) {
+            model.artifact.flashOffset = model.flashOffset;
+          }
         }
         render();
         break;

--- a/media/ftp.css
+++ b/media/ftp.css
@@ -65,16 +65,6 @@ body {
   background: var(--vscode-sideBarSectionHeader-background, transparent);
 }
 
-.toolbar .status {
-  flex: 1;
-  min-width: 120px;
-  color: var(--muted);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-size: 12px;
-}
-
 /* Cursor-style view "…" control: ellipsis vertically centered in the hit target */
 .toolbar .more-btn {
   width: 24px;

--- a/media/ftp.js
+++ b/media/ftp.js
@@ -473,11 +473,6 @@
 
   function updateChrome() {
     const on = state.connected;
-    const info = on && state.deviceInfo ? ` — ${state.deviceInfo}` : "";
-    $("status").textContent = on
-      ? `Connected: ${state.device}${info}`
-      : "Not connected";
-    $("status").title = on && state.deviceInfo ? state.deviceInfo : "";
     $("btnConnect").textContent = on ? "Disconnect" : "Connect";
     $("btnXferUp").disabled = !on;
     $("btnXferDown").disabled = !on;

--- a/python/firmware_download.py
+++ b/python/firmware_download.py
@@ -1,0 +1,647 @@
+"""
+Official MicroPython firmware catalog + download (Thonny-compatible).
+
+Catalog source (same as Thonny):
+  https://raw.githubusercontent.com/thonny/thonny/master/data/
+    micropython-variants-esptool.json
+    micropython-variants-uf2.json
+
+Binary URLs inside those JSON files point at micropython.org/resources/firmware/.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+import urllib.error
+import urllib.request
+from pathlib import Path
+from typing import Any, Callable, Optional
+from urllib.parse import unquote, urlparse
+
+DEFAULT_DATA_PREFIX = "https://raw.githubusercontent.com/thonny/thonny/master/data"
+ESPTOOL_JSON = "micropython-variants-esptool.json"
+UF2_JSON = "micropython-variants-uf2.json"
+# Official board.json (deploy_options.flash_offset, mcu, …) — same source as a
+# MicroPython checkout's ports/<port>/boards/<board>/board.json.
+MP_BOARD_JSON_PREFIX = (
+    "https://raw.githubusercontent.com/micropython/micropython/master/ports"
+)
+
+CACHE_ROOT = Path.home() / ".mpftp" / "firmware-cache"
+INDEX_TTL_SEC = 24 * 3600
+
+# Map Thonny ``family`` → mpftp flasher port.
+_FAMILY_TO_PORT = {
+    "esp32": "esp32",
+    "esp32s2": "esp32",
+    "esp32s3": "esp32",
+    "esp32c2": "esp32",
+    "esp32c3": "esp32",
+    "esp32c5": "esp32",
+    "esp32c6": "esp32",
+    "esp32h2": "esp32",
+    "esp32p4": "esp32",
+    "rp2": "rp2",
+    "samd21": "samd",
+    "samd51": "samd",
+}
+
+Fetcher = Callable[[str, float], str]
+
+
+def cache_root() -> Path:
+    CACHE_ROOT.mkdir(parents=True, exist_ok=True)
+    (CACHE_ROOT / "index").mkdir(exist_ok=True)
+    (CACHE_ROOT / "files").mkdir(exist_ok=True)
+    return CACHE_ROOT
+
+
+def default_fetch(url: str, timeout: float = 30.0) -> str:
+    req = urllib.request.Request(
+        url,
+        headers={"User-Agent": "mpftp/0.1 (MicroPython firmware download)"},
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        return resp.read().decode("utf-8", errors="replace")
+
+
+def board_id_from_info_url(info_url: str) -> str:
+    path = urlparse(info_url or "").path.rstrip("/")
+    return unquote(path.split("/")[-1]) if path else ""
+
+
+def port_for_family(family: str) -> str:
+    fam = (family or "").lower()
+    return _FAMILY_TO_PORT.get(fam, fam or "unknown")
+
+
+def normalize_variant(raw: dict[str, Any]) -> dict[str, Any]:
+    """Normalize a Thonny variant entry for mpftp Target / download UI."""
+    info_url = raw.get("info_url") or ""
+    board = board_id_from_info_url(info_url)
+    family = str(raw.get("family") or "")
+    downloads = list(raw.get("downloads") or [])
+    return {
+        "board": board,
+        "vendor": raw.get("vendor") or "",
+        "model": raw.get("model") or "",
+        "family": family,
+        "port": port_for_family(family),
+        "info_url": info_url,
+        "downloads": downloads,
+        "latest_prerelease_regex": raw.get("latest_prerelease_regex"),
+        "popular": bool(raw.get("popular", False)),
+        "title": raw.get("title") or raw.get("model") or board,
+    }
+
+
+def _index_path(name: str) -> Path:
+    return cache_root() / "index" / name
+
+
+def _board_json_cache_path(port: str, board: str) -> Path:
+    safe_port = re.sub(r"[^\w.-]+", "_", port or "esp32")
+    safe_board = re.sub(r"[^\w.-]+", "_", board or "unknown")
+    return cache_root() / "board-json" / safe_port / f"{safe_board}.json"
+
+
+def normalize_flash_offset(raw: Any) -> str:
+    """Normalize board.json flash_offset values (``0``, ``0x0``, ``0x2000``)."""
+    s = str(raw).strip()
+    if not s:
+        return "0x0"
+    try:
+        return hex(int(s, 0))
+    except ValueError:
+        return s if s.lower().startswith("0x") else f"0x{s}"
+
+
+def board_json_url(board: str, port: str = "esp32") -> str:
+    return f"{MP_BOARD_JSON_PREFIX.rstrip('/')}/{port}/boards/{board}/board.json"
+
+
+def fetch_board_json(
+    board: str,
+    *,
+    port: str = "esp32",
+    fetch: Optional[Fetcher] = None,
+    force: bool = False,
+) -> Optional[dict[str, Any]]:
+    """Fetch and cache ``board.json`` from the MicroPython GitHub tree."""
+    if not board:
+        return None
+    fetch = fetch or default_fetch
+    path = _board_json_cache_path(port, board)
+    if not force:
+        cached = _load_cached_json(path)
+        if isinstance(cached, dict):
+            return cached
+    url = board_json_url(board, port)
+    try:
+        text = fetch(url)
+        data = json.loads(text)
+    except Exception:
+        return None
+    if not isinstance(data, dict):
+        return None
+    _save_cached_json(path, data)
+    return data
+
+
+def flash_offset_from_board_json(data: dict[str, Any]) -> Optional[str]:
+    """Return deploy_options.flash_offset when present (normalized)."""
+    deploy = data.get("deploy_options") or {}
+    if not isinstance(deploy, dict):
+        return None
+    raw = deploy.get("flash_offset")
+    if raw is None or str(raw).strip() == "":
+        return None
+    return normalize_flash_offset(raw)
+
+
+def resolve_remote_flash_offset(
+    board: str,
+    *,
+    port: str = "esp32",
+    fetch: Optional[Fetcher] = None,
+    force: bool = False,
+) -> Optional[str]:
+    """Flash offset from upstream board.json, or None if unavailable."""
+    data = fetch_board_json(board, port=port, fetch=fetch, force=force)
+    if not data:
+        return None
+    return flash_offset_from_board_json(data)
+
+
+def _load_cached_json(path: Path, ttl: float = INDEX_TTL_SEC) -> Optional[Any]:
+    try:
+        if not path.is_file():
+            return None
+        age = time.time() - path.stat().st_mtime
+        if age > ttl:
+            return None
+        return json.loads(path.read_text("utf-8"))
+    except Exception:
+        return None
+
+
+def _save_cached_json(path: Path, data: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(data, indent=2), encoding="utf-8")
+
+
+def fetch_variants_json(
+    filename: str,
+    *,
+    data_prefix: str = DEFAULT_DATA_PREFIX,
+    fetch: Optional[Fetcher] = None,
+    force: bool = False,
+) -> list[dict[str, Any]]:
+    fetch = fetch or default_fetch
+    path = _index_path(filename)
+    if not force:
+        cached = _load_cached_json(path)
+        if isinstance(cached, list):
+            return cached
+    url = data_prefix.rstrip("/") + "/" + filename
+    text = fetch(url)
+    data = json.loads(text)
+    if not isinstance(data, list):
+        raise ValueError(f"unexpected variants JSON shape from {url}")
+    _save_cached_json(path, data)
+    return data
+
+
+def load_catalog(
+    *,
+    data_prefix: str = DEFAULT_DATA_PREFIX,
+    fetch: Optional[Fetcher] = None,
+    force: bool = False,
+) -> list[dict[str, Any]]:
+    """Load and merge esptool + uf2 variant catalogs."""
+    merged: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for filename in (ESPTOOL_JSON, UF2_JSON):
+        for raw in fetch_variants_json(
+            filename, data_prefix=data_prefix, fetch=fetch, force=force
+        ):
+            v = normalize_variant(raw)
+            key = v["board"] or f"{v['vendor']}:{v['model']}:{v['family']}"
+            if key in seen:
+                continue
+            seen.add(key)
+            merged.append(v)
+    merged.sort(
+        key=lambda v: (
+            v["port"],
+            (v["vendor"] or "").lower(),
+            (v["model"] or "").lower(),
+            v["board"],
+        )
+    )
+    return merged
+
+
+def catalog_tree(
+    catalog: Optional[list[dict[str, Any]]] = None,
+    **load_kw: Any,
+) -> dict[str, Any]:
+    """Group catalog for UI: ports -> boards (flashable families only)."""
+    if catalog is None:
+        catalog = load_catalog(**load_kw)
+    flashers = {"esp32": "esptool", "rp2": "uf2", "samd": "uf2"}
+    ports: dict[str, dict[str, Any]] = {}
+    for v in catalog:
+        port = v["port"]
+        if port not in ("esp32", "rp2", "samd"):
+            continue
+        bucket = ports.setdefault(
+            port,
+            {
+                "port": port,
+                "kind": "boards",
+                "flashable": True,
+                "flasher": flashers.get(port, ""),
+                "boards": [],
+            },
+        )
+        label = v["board"]
+        if v.get("vendor") or v.get("model"):
+            label = f"{v.get('vendor', '')} {v.get('model', '')}".strip() + f" ({v['board']})"
+        bucket["boards"].append(
+            {
+                "board": v["board"],
+                "vendor": v["vendor"],
+                "model": v["model"],
+                "family": v["family"],
+                "title": v["title"],
+                "label": label,
+                "info_url": v["info_url"],
+                "popular": v["popular"],
+                "versions": [d.get("version") for d in v["downloads"] if d.get("version")],
+            }
+        )
+    # Stable port order
+    ordered = [ports[p] for p in ("esp32", "rp2", "samd") if p in ports]
+    return {"ports": ordered, "source": "thonny-variants"}
+
+
+def find_variant(
+    board: str, catalog: Optional[list[dict[str, Any]]] = None, **load_kw: Any
+) -> Optional[dict[str, Any]]:
+    if catalog is None:
+        catalog = load_catalog(**load_kw)
+    board_u = (board or "").upper()
+    for v in catalog:
+        if (v.get("board") or "").upper() == board_u:
+            return v
+    return None
+
+
+def _is_preview_version(version: str) -> bool:
+    v = (version or "").lower()
+    return "preview" in v or "pre" in v.split(".")[0:1]
+
+
+def list_downloads(variant: dict[str, Any]) -> list[dict[str, str]]:
+    """Downloads from the Thonny JSON entry (base board image only)."""
+    out: list[dict[str, str]] = []
+    for d in variant.get("downloads") or []:
+        ver = str(d.get("version") or "")
+        url = str(d.get("url") or "")
+        if not ver or not url:
+            continue
+        out.append(
+            {
+                "version": ver.lstrip("v"),
+                "url": url,
+                "channel": "preview" if _is_preview_version(ver) else "release",
+                "mp_variant": "",
+            }
+        )
+    return out
+
+
+def _fetch_board_html(info_url: str, fetch: Fetcher) -> str:
+    try:
+        return fetch(info_url if info_url.endswith("/") else info_url + "/")
+    except Exception:
+        return fetch(info_url)
+
+
+def parse_board_page_firmware(board: str, html: str) -> dict[str, list[dict[str, str]]]:
+    """Group firmware links from a micropython.org board page by MP variant.
+
+    Filenames look like:
+      ESP32_GENERIC_P4-20260406-v1.28.0.bin          → mp_variant ""
+      ESP32_GENERIC_P4-C6_WIFI-20260406-v1.28.0.bin → mp_variant "C6_WIFI"
+    """
+    # Variant must start with a letter so the date (8 digits) is not captured as one.
+    file_re = re.compile(
+        rf"{re.escape(board)}"
+        rf"(?:-([A-Za-z_][A-Za-z0-9_]*))?"
+        rf"-(\d{{8}})-(v[\w.+-]+)\.(bin|uf2)",
+        re.I,
+    )
+    by_variant: dict[str, list[dict[str, str]]] = {}
+    seen: set[str] = set()
+    for rel in re.findall(
+        r'href="(/resources/firmware/[^"]+\.(?:bin|uf2))"', html, flags=re.I
+    ):
+        name = rel.rsplit("/", 1)[-1]
+        m = file_re.fullmatch(name) or file_re.search(name)
+        if not m:
+            continue
+        mp_var = m.group(1) or ""
+        ver = m.group(3).lstrip("v")
+        url = "https://micropython.org" + rel
+        if url in seen:
+            continue
+        seen.add(url)
+        by_variant.setdefault(mp_var, []).append(
+            {
+                "version": ver,
+                "url": url,
+                "channel": "preview" if _is_preview_version(ver) else "release",
+                "mp_variant": mp_var,
+            }
+        )
+    for key in by_variant:
+        by_variant[key] = _sort_download_list(by_variant[key])
+    return by_variant
+
+
+def _sort_download_list(items: list[dict[str, str]]) -> list[dict[str, str]]:
+    releases = [d for d in items if d["channel"] == "release"]
+    previews = [d for d in items if d["channel"] == "preview"]
+    releases.sort(key=lambda d: d["version"], reverse=True)
+    previews.sort(key=lambda d: d["version"], reverse=True)
+    return releases + previews
+
+
+def enrich_downloads_from_page(
+    variant: dict[str, Any],
+    *,
+    fetch: Optional[Fetcher] = None,
+) -> dict[str, list[dict[str, str]]]:
+    """Scrape the board page for all MP-variant firmware; fall back to JSON."""
+    fetch = fetch or default_fetch
+    json_default = list_downloads(variant)
+    info_url = variant.get("info_url") or ""
+    board = variant.get("board") or ""
+    if info_url and board:
+        try:
+            html = _fetch_board_html(info_url, fetch)
+            parsed = parse_board_page_firmware(board, html)
+            if parsed:
+                # Merge Thonny JSON entries for the default image when the page
+                # scrape is incomplete (tests / transient HTML).
+                seen = {d["url"] for d in parsed.get("", [])}
+                for d in json_default:
+                    if d["url"] not in seen:
+                        parsed.setdefault("", []).append(d)
+                for key in list(parsed.keys()):
+                    parsed[key] = _sort_download_list(parsed[key])
+                return parsed
+        except Exception:
+            pass
+    return {"": json_default}
+
+
+def pick_download(
+    variant: dict[str, Any],
+    *,
+    version: Optional[str] = None,
+    preview: bool = False,
+    mp_variant: str = "",
+    fetch: Optional[Fetcher] = None,
+) -> dict[str, str]:
+    """Choose a download entry for board + MP variant (e.g. C6_WIFI)."""
+    by_var = enrich_downloads_from_page(variant, fetch=fetch)
+    mp_variant = mp_variant or ""
+    if mp_variant not in by_var:
+        known = ", ".join(sorted(by_var.keys()) or ["(none)"])
+        raise RuntimeError(
+            f"variant {mp_variant or '(default)'} not available for "
+            f"{variant.get('board')}; have: {known}"
+        )
+    downloads = by_var[mp_variant]
+    if preview:
+        for d in downloads:
+            if d["channel"] == "preview":
+                return d
+        # Fall back to Thonny regex tweak filtered by variant name in URL.
+        patched = maybe_latest_preview(
+            variant, fetch=fetch, mp_variant=mp_variant, by_variant=by_var
+        )
+        if patched:
+            return patched
+        raise RuntimeError(
+            f"no preview build for {variant.get('board')}"
+            + (f" / {mp_variant}" if mp_variant else "")
+        )
+    if version:
+        ver = version.lstrip("v")
+        for d in downloads:
+            if d["version"].lstrip("v") == ver:
+                return d
+        raise RuntimeError(
+            f"version {version} not found for {variant.get('board')}"
+            + (f" / {mp_variant}" if mp_variant else "")
+        )
+    for d in downloads:
+        if d["channel"] == "release":
+            return d
+    if downloads:
+        return downloads[0]
+    raise RuntimeError(f"no downloads for {variant.get('board')}")
+
+
+def maybe_latest_preview(
+    variant: dict[str, Any],
+    *,
+    fetch: Optional[Fetcher] = None,
+    mp_variant: str = "",
+    by_variant: Optional[dict[str, list[dict[str, str]]]] = None,
+) -> Optional[dict[str, str]]:
+    """Pick latest preview for an MP variant from scraped page data."""
+    if by_variant is None:
+        by_variant = enrich_downloads_from_page(variant, fetch=fetch)
+    for d in by_variant.get(mp_variant or "", []):
+        if d["channel"] == "preview":
+            return d
+    # Thonny regex fallback (base image only).
+    regex_s = variant.get("latest_prerelease_regex")
+    info_url = variant.get("info_url") or ""
+    if not regex_s or not info_url:
+        return None
+    fetch = fetch or default_fetch
+    try:
+        html = _fetch_board_html(info_url, fetch)
+    except Exception:
+        return None
+    try:
+        rx = re.compile(regex_s)
+    except re.error:
+        return None
+    urls = re.findall(
+        r'href="(/resources/firmware/[^"]+\.(?:bin|uf2))"', html, flags=re.I
+    )
+    for rel in urls:
+        name = rel.rsplit("/", 1)[-1]
+        if mp_variant and mp_variant not in name:
+            continue
+        if mp_variant == "" and re.search(
+            rf"{re.escape(variant.get('board') or '')}-[A-Za-z_]", name
+        ):
+            # Skip variant-tagged files when asking for the default image.
+            continue
+        m = rx.search(name)
+        if not m:
+            continue
+        ver_m = re.search(r"(v?\d+\.\d+\.\d+-preview\.\d+\.[a-z0-9]+)", name, re.I)
+        version = ver_m.group(1) if ver_m else m.group(0)
+        return {
+            "version": version.lstrip("v"),
+            "url": "https://micropython.org" + rel,
+            "channel": "preview",
+            "mp_variant": mp_variant,
+        }
+    return None
+
+
+def download_file(
+    url: str,
+    *,
+    dest_dir: Optional[Path] = None,
+    progress: Optional[Callable[[int, int], None]] = None,
+) -> Path:
+    """Download URL into firmware-cache/files; skip if same-sized file exists."""
+    dest_dir = dest_dir or (cache_root() / "files")
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    name = unquote(urlparse(url).path.rsplit("/", 1)[-1]) or "firmware.bin"
+    dest = dest_dir / name
+
+    req = urllib.request.Request(
+        url, headers={"User-Agent": "mpftp/0.1 (MicroPython firmware download)"}
+    )
+    with urllib.request.urlopen(req, timeout=120) as resp:
+        total = int(resp.headers.get("Content-Length") or 0)
+        if dest.is_file() and total and dest.stat().st_size == total:
+            if progress:
+                progress(total, total)
+            return dest
+        tmp = dest.with_suffix(dest.suffix + ".partial")
+        written = 0
+        with open(tmp, "wb") as f:
+            while True:
+                chunk = resp.read(256 * 1024)
+                if not chunk:
+                    break
+                f.write(chunk)
+                written += len(chunk)
+                if progress and total:
+                    progress(written, total)
+        tmp.replace(dest)
+    return dest
+
+
+def download_board(
+    board: str,
+    *,
+    version: Optional[str] = None,
+    preview: bool = False,
+    mp_variant: str = "",
+    data_prefix: str = DEFAULT_DATA_PREFIX,
+    fetch: Optional[Fetcher] = None,
+    catalog: Optional[list[dict[str, Any]]] = None,
+) -> dict[str, Any]:
+    """Resolve board + MP variant + version, download, return artifact-shaped dict."""
+    variant = find_variant(board, catalog=catalog, data_prefix=data_prefix, fetch=fetch)
+    if not variant:
+        raise RuntimeError(f"board not in download catalog: {board}")
+    chosen = pick_download(
+        variant,
+        version=version,
+        preview=preview,
+        mp_variant=mp_variant or "",
+        fetch=fetch,
+    )
+    path = download_file(chosen["url"])
+    st = path.stat()
+    flash_offset = resolve_remote_flash_offset(
+        variant["board"], port=variant["port"] or "esp32", fetch=fetch
+    )
+    out: dict[str, Any] = {
+        "ready": True,
+        "artifact": str(path),
+        "size": st.st_size,
+        "mtime": st.st_mtime,
+        "source": "download",
+        "board": variant["board"],
+        "variant": mp_variant or "",
+        "version": chosen["version"],
+        "family": variant["family"],
+        "port": variant["port"],
+        "url": chosen["url"],
+        "info_url": variant["info_url"],
+        "vendor": variant["vendor"],
+        "model": variant["model"],
+    }
+    if flash_offset:
+        out["flashOffset"] = flash_offset
+    return out
+
+
+def list_board(
+    board: str,
+    *,
+    mp_variant: str = "",
+    data_prefix: str = DEFAULT_DATA_PREFIX,
+    fetch: Optional[Fetcher] = None,
+    catalog: Optional[list[dict[str, Any]]] = None,
+    include_preview_probe: bool = False,
+    force: bool = False,
+) -> dict[str, Any]:
+    variant = find_variant(
+        board, catalog=catalog, data_prefix=data_prefix, fetch=fetch, force=force
+    )
+    if not variant:
+        raise RuntimeError(f"board not in download catalog: {board}")
+    by_var = enrich_downloads_from_page(variant, fetch=fetch)
+    # UI "variants" are named MP builds (C6_WIFI, …); default "" is separate.
+    variants = sorted(k for k in by_var.keys() if k)
+    mp_variant = mp_variant or ""
+    if mp_variant and mp_variant not in by_var:
+        downloads: list[dict[str, str]] = []
+    else:
+        downloads = list(by_var.get(mp_variant, by_var.get("", [])))
+    preview = None
+    if include_preview_probe:
+        preview = maybe_latest_preview(
+            variant, fetch=fetch, mp_variant=mp_variant, by_variant=by_var
+        )
+    flash_offset = resolve_remote_flash_offset(
+        variant["board"],
+        port=variant["port"] or "esp32",
+        fetch=fetch,
+        force=force,
+    )
+    out: dict[str, Any] = {
+        "board": variant["board"],
+        "vendor": variant["vendor"],
+        "model": variant["model"],
+        "family": variant["family"],
+        "port": variant["port"],
+        "info_url": variant["info_url"],
+        "variants": variants,
+        "variant": mp_variant,
+        "downloads": downloads,
+        "preview": preview,
+    }
+    if flash_offset:
+        out["flashOffset"] = flash_offset
+    return out

--- a/python/firmware_engine.py
+++ b/python/firmware_engine.py
@@ -1064,25 +1064,67 @@ _BOOTLOADER_OFFSET_BY_MCU = {
 }
 
 
-def esp32_flash_offset(port_dir: Path, board: str) -> str:
+def esp32_flash_offset_for_family(family: str) -> str:
+    """Bootloader offset from MCU family string (e.g. Thonny catalog ``family``)."""
+    mcu = (family or "").lower().replace("-", "")
+    return _BOOTLOADER_OFFSET_BY_MCU.get(mcu, "0x0")
+
+
+def esp32_flash_offset(port_dir: Path, board: str, family: str = "") -> str:
     """Resolve the esp32 flash offset for ``board``.
 
-    Prefers ``board.json``'s ``deploy_options.flash_offset``; when that is
-    absent, infers the bootloader offset from the chip family (``board.json``
-    ``mcu``) — classic/S2 at 0x1000, P4 at 0x2000, newer parts at 0x0.
+    Prefers ``board.json``'s ``deploy_options.flash_offset`` from:
+      1. local MicroPython tree (``port_dir/boards/<board>/board.json``)
+      2. upstream GitHub copy of the same file (download mode / no checkout)
+    When that is absent, infers from ``board.json`` ``mcu`` / catalog ``family``
+    — classic/S2 at 0x1000, P4 at 0x2000, newer parts at 0x0.
     """
+    if board and port_dir:
+        bj = port_dir / "boards" / board / "board.json"
+        try:
+            data = json.loads(bj.read_text("utf-8"))
+            explicit = data.get("deploy_options", {}).get("flash_offset")
+            if explicit is not None and str(explicit).strip() != "":
+                try:
+                    from firmware_download import normalize_flash_offset
+
+                    return normalize_flash_offset(explicit)
+                except Exception:
+                    return str(explicit)
+            mcu = str(data.get("mcu", "")).lower()
+            if mcu:
+                return _BOOTLOADER_OFFSET_BY_MCU.get(mcu, "0x0")
+        except Exception:
+            pass
+    if board:
+        try:
+            from firmware_download import resolve_remote_flash_offset
+
+            # Catalog / UI port is esp32 for all Espressif families; GitHub path
+            # is always ports/esp32/boards/<BOARD>/board.json.
+            remote = resolve_remote_flash_offset(board, port="esp32")
+            if remote:
+                return remote
+            # board.json without deploy_options.flash_offset — use its mcu.
+            from firmware_download import fetch_board_json
+
+            data = fetch_board_json(board, port="esp32")
+            if data:
+                mcu = str(data.get("mcu", "")).lower()
+                if mcu:
+                    return _BOOTLOADER_OFFSET_BY_MCU.get(mcu, "0x0")
+        except Exception:
+            pass
+    if family:
+        return esp32_flash_offset_for_family(family)
     if not board:
         return "0x0"
-    bj = port_dir / "boards" / board / "board.json"
-    try:
-        data = json.loads(bj.read_text("utf-8"))
-    except Exception:
-        return "0x0"
-    explicit = data.get("deploy_options", {}).get("flash_offset")
-    if explicit:
-        return str(explicit)
-    mcu = str(data.get("mcu", "")).lower()
-    return _BOOTLOADER_OFFSET_BY_MCU.get(mcu, "0x0")
+    # Guess from board name when no tree / family (e.g. ESP32_GENERIC_S3).
+    name = board.upper()
+    for key in ("ESP32P4", "ESP32C6", "ESP32C5", "ESP32C3", "ESP32C2", "ESP32S3", "ESP32S2", "ESP32"):
+        if key in name.replace("_", ""):
+            return esp32_flash_offset_for_family(key.lower())
+    return "0x0"
 
 
 def _wslpath_w(p: str) -> str:
@@ -1122,6 +1164,12 @@ def _esptool_cmd(ns: argparse.Namespace) -> list[str]:
 _PARTITION_TABLE_OFFSET = 0x8000
 
 
+def _esptool_reset_mode(value: str, default: str) -> str:
+    """Normalize esptool v5 reset-mode names (hyphens; accept legacy underscores)."""
+    v = (value or "").strip().replace("_", "-")
+    return v or default
+
+
 def _read_device_partition_table(base: list[str], nbytes: int) -> Optional[bytes]:
     """Read the on-device partition-table region, or None if it can't be read.
 
@@ -1131,8 +1179,16 @@ def _read_device_partition_table(base: list[str], nbytes: int) -> Optional[bytes
     import tempfile
     tmp = Path(tempfile.gettempdir()) / f"mpftp_pt_{os.getpid()}.bin"
     out_arg = _wslpath_w(str(tmp)) if HOST == "wsl" else str(tmp)
-    cmd = base + ["--before", "default_reset", "--after", "no_reset",
-                  "read_flash", hex(_PARTITION_TABLE_OFFSET), hex(nbytes), out_arg]
+    cmd = base + [
+        "--before",
+        "default-reset",
+        "--after",
+        "no-reset",
+        "read-flash",
+        hex(_PARTITION_TABLE_OFFSET),
+        hex(nbytes),
+        out_arg,
+    ]
     try:
         r = subprocess.run(cmd, capture_output=True, text=True, timeout=60)
         if r.returncode != 0 or not tmp.is_file():
@@ -1166,10 +1222,11 @@ def _esp32_layout_changed(base: list[str], artifact: Path) -> Optional[bool]:
     return got[: len(want)] != want
 
 
-def flash_esp32(ns: argparse.Namespace, mp: Path, artifact: Path) -> None:
-    port_dir = mp / "ports" / ns.port
+def flash_esp32(ns: argparse.Namespace, mp: Optional[Path], artifact: Path) -> None:
+    port_dir = (mp / "ports" / ns.port) if mp else Path(".")
+    family = getattr(ns, "family", "") or ""
     offset = (getattr(ns, "offset", "") or "").strip() or esp32_flash_offset(
-        port_dir, ns.board or ""
+        port_dir, ns.board or "", family=family
     )
     emit_log(f"[mpftp] flash offset {offset}")
     fw = str(artifact)
@@ -1191,14 +1248,13 @@ def flash_esp32(ns: argparse.Namespace, mp: Path, artifact: Path) -> None:
 
     if erase:
         emit_log("[mpftp] erasing flash…")
-        rc = stream_process(base + ["erase_flash"], Path.cwd(), dict(os.environ))
+        rc = stream_process(base + ["erase-flash"], Path.cwd(), dict(os.environ))
         if rc != 0:
-            emit_result(False, error=f"erase_flash failed (exit {rc})")
+            emit_result(False, error=f"erase-flash failed (exit {rc})")
             return
-    before = getattr(ns, "before", "") or "default_reset"
-    after = getattr(ns, "after", "") or "hard_reset"
-    full = base + ["--before", before, "--after", after,
-                   "write_flash", offset, fw]
+    before = _esptool_reset_mode(getattr(ns, "before", "") or "", "default-reset")
+    after = _esptool_reset_mode(getattr(ns, "after", "") or "", "hard-reset")
+    full = base + ["--before", before, "--after", after, "write-flash", offset, fw]
     rc = stream_process(full, Path.cwd(), dict(os.environ))
     if rc != 0:
         emit_result(False, error=f"esptool failed (exit {rc})")
@@ -1279,16 +1335,21 @@ def _looks_like_mount(dev: str) -> bool:
 
 
 def do_flash(ns: argparse.Namespace) -> None:
-    mp = Path(ns.mp).expanduser().resolve()
     port = ns.port
     board = ns.board or ""
     variant = ns.variant or ""
     if port not in FLASHERS:
         emit_result(False, error=f"Flashing not supported for port '{port}'.")
         return
+    mp: Optional[Path] = None
+    if getattr(ns, "mp", None):
+        mp = Path(ns.mp).expanduser().resolve()
     if ns.artifact:
         artifact = Path(ns.artifact).expanduser()
     else:
+        if not mp:
+            emit_result(False, error="No artifact path and no MicroPython tree for last build.")
+            return
         info = artifact_info(mp, port, board, variant)
         if not info["ready"]:
             emit_result(False, error="No build found for this selection. Build first.")
@@ -2034,11 +2095,15 @@ def do_detect(ns: argparse.Namespace) -> None:
         if _is_mp_tree(mp):
             tree = build_tree(mp)
 
-    rc, fout = _esptool_capture(ns, ["flash_id"])
+    # Always hard-reset after probing. esptool's default download-mode entry
+    # otherwise leaves the chip in "waiting for download" and Connect fails
+    # until a button reset (seen on ESP32-P4 + USB-UART bridges).
+    _esp_probe = ["--before", "default-reset", "--after", "hard-reset"]
+    rc, fout = _esptool_capture(ns, _esp_probe + ["flash-id"])
     flash = parse_esptool_flash_id(fout)
     sec = {"available": False, "secureBoot": "", "flashEncryption": ""}
     if flash.get("chip"):
-        _src, srout = _esptool_capture(ns, ["get_security_info"])
+        _src, srout = _esptool_capture(ns, _esp_probe + ["get-security-info"])
         sec = parse_esptool_security(srout)
 
     esp_from_mp = _mp_indicates_esp(mp_hints)
@@ -2165,6 +2230,89 @@ def do_artifact(ns: argparse.Namespace) -> None:
     print_json(artifact_info(mp, ns.port, ns.board or "", ns.variant or ""))
 
 
+def do_download_tree(ns: argparse.Namespace) -> None:
+    from firmware_download import catalog_tree
+
+    force = bool(getattr(ns, "force", False))
+    print_json(catalog_tree(force=force))
+
+
+def do_download_list(ns: argparse.Namespace) -> None:
+    from firmware_download import list_board
+
+    board = ns.board or ""
+    if not board:
+        print_json({"error": "board required"})
+        raise SystemExit(1)
+    try:
+        print_json(
+            list_board(
+                board,
+                mp_variant=getattr(ns, "variant", None) or "",
+                include_preview_probe=bool(getattr(ns, "preview", False)),
+                force=bool(getattr(ns, "force", False)),
+            )
+        )
+    except Exception as e:  # noqa: BLE001
+        print_json({"error": str(e)})
+        raise SystemExit(1)
+
+
+def do_download(ns: argparse.Namespace) -> None:
+    from firmware_download import download_file, find_variant, load_catalog, pick_download
+
+    board = ns.board or ""
+    if not board:
+        emit_result(False, error="board required")
+        return
+    try:
+        def progress(done: int, total: int) -> None:
+            if total:
+                pct = int(100 * done / total)
+                emit_log(f"[mpftp] download {pct}% ({done}/{total})")
+
+        force = bool(getattr(ns, "force", False))
+        mp_variant = getattr(ns, "variant", None) or ""
+        catalog = load_catalog(force=force)
+        variant = find_variant(board, catalog=catalog)
+        if not variant:
+            raise RuntimeError(f"board not in download catalog: {board}")
+        chosen = pick_download(
+            variant,
+            version=getattr(ns, "version", None) or None,
+            preview=bool(getattr(ns, "preview", False)),
+            mp_variant=mp_variant,
+        )
+        emit_log(f"[mpftp] downloading {chosen['url']}")
+        path = download_file(chosen["url"], progress=progress)
+        st = path.stat()
+        from firmware_download import resolve_remote_flash_offset
+
+        flash_offset = resolve_remote_flash_offset(
+            variant["board"], port=variant["port"] or "esp32"
+        )
+        emit_result(
+            True,
+            ready=True,
+            artifact=str(path),
+            size=st.st_size,
+            mtime=st.st_mtime,
+            source="download",
+            board=variant["board"],
+            variant=mp_variant,
+            version=chosen["version"],
+            family=variant["family"],
+            port=variant["port"],
+            url=chosen["url"],
+            info_url=variant["info_url"],
+            vendor=variant["vendor"],
+            model=variant["model"],
+            flashOffset=flash_offset or None,
+        )
+    except Exception as e:  # noqa: BLE001
+        emit_result(False, error=str(e))
+
+
 def do_flashers(_ns: argparse.Namespace) -> None:
     print_json({"flashers": FLASHERS})
 
@@ -2221,24 +2369,60 @@ def build_parser() -> argparse.ArgumentParser:
     cl.set_defaults(func=do_clean)
 
     f = sub.add_parser("flash")
-    add_mp(f, required=True)
+    add_mp(f, required=False)  # optional when --artifact is a downloaded file
     f.add_argument("--port", required=True)
     f.add_argument("--board", default="")
     f.add_argument("--variant", default="")
+    f.add_argument("--family", default="", help="MCU family for flash offset (download mode)")
     f.add_argument("--device", default="")
     f.add_argument("--artifact", default="")
     f.add_argument("--baud", type=int, default=460800)
     f.add_argument("--offset", default="",
                    help="esp32 flash offset override (default: board.json / chip family)")
     f.add_argument("--erase", action="store_true")
-    f.add_argument("--before", default="default_reset",
-                   choices=["default_reset", "no_reset", "usb_reset"],
-                   help="esp32 reset mode before flashing")
-    f.add_argument("--after", default="hard_reset",
-                   choices=["hard_reset", "soft_reset", "no_reset"],
-                   help="esp32 reset mode after flashing")
+    f.add_argument(
+        "--before",
+        default="default-reset",
+        type=lambda s: str(s).replace("_", "-"),
+        choices=["default-reset", "no-reset", "usb-reset"],
+        help="esp32 reset mode before flashing (esptool --before)",
+    )
+    f.add_argument(
+        "--after",
+        default="hard-reset",
+        type=lambda s: str(s).replace("_", "-"),
+        choices=["hard-reset", "soft-reset", "no-reset"],
+        help="esp32 reset mode after flashing (esptool --after)",
+    )
     f.add_argument("--esptool", default=None, help="esptool interpreter/executable")
     f.set_defaults(func=do_flash)
+
+    dlt = sub.add_parser("download-tree", help="Official firmware catalog (Thonny JSON)")
+    dlt.add_argument("--force", action="store_true", help="refresh catalog cache")
+    dlt.set_defaults(func=do_download_tree)
+
+    dll = sub.add_parser("download-list", help="List downloadable versions for a board")
+    dll.add_argument("--board", required=True)
+    dll.add_argument(
+        "--variant",
+        default="",
+        help="MP board variant (e.g. C6_WIFI for ESP32_GENERIC_P4)",
+    )
+    dll.add_argument("--preview", action="store_true", help="probe board page for latest preview")
+    dll.add_argument("--force", action="store_true")
+    dll.set_defaults(func=do_download_list)
+
+    dld = sub.add_parser("download", help="Download official firmware for a board")
+    dld.add_argument("--board", required=True)
+    dld.add_argument(
+        "--variant",
+        default="",
+        help="MP board variant (e.g. C6_WIFI for ESP32_GENERIC_P4)",
+    )
+    dld.add_argument("--version", default="", help="release version (e.g. 1.28.0)")
+    dld.add_argument("--preview", action="store_true", help="latest preview build")
+    dld.add_argument("--force", action="store_true", help="refresh catalog cache")
+    dld.set_defaults(func=do_download)
 
     fl = sub.add_parser("flashers")
     fl.set_defaults(func=do_flashers)
@@ -2277,7 +2461,7 @@ def main(argv: Optional[list[str]] = None) -> None:
     except BrokenPipeError:
         pass
     except Exception as e:  # noqa: BLE001
-        if ns.cmd in ("build", "clean", "flash"):
+        if ns.cmd in ("build", "clean", "flash", "download"):
             emit_result(False, error=str(e))
         else:
             print_json({"error": str(e)})

--- a/python/mpftp_cli.py
+++ b/python/mpftp_cli.py
@@ -789,9 +789,42 @@ def cmd_firmware(ns: argparse.Namespace) -> None:
             extra += ["--device", ns.device]
         if getattr(ns, "artifact", None):
             extra += ["--artifact", ns.artifact]
+        if getattr(ns, "family", None):
+            extra += ["--family", ns.family]
         if getattr(ns, "erase", False):
             extra.append("--erase")
         res = _engine_stream("flash", extra)
+        out(res)
+        if not res.get("ok"):
+            raise SystemExit(1)
+        return
+    if sub == "download-tree":
+        extra = []
+        if getattr(ns, "force", False):
+            extra.append("--force")
+        out(_engine_json("download-tree", extra))
+        return
+    if sub == "download-list":
+        extra = ["--board", ns.board]
+        if getattr(ns, "variant", None):
+            extra += ["--variant", ns.variant]
+        if getattr(ns, "preview", False):
+            extra.append("--preview")
+        if getattr(ns, "force", False):
+            extra.append("--force")
+        out(_engine_json("download-list", extra))
+        return
+    if sub == "download":
+        extra = ["--board", ns.board]
+        if getattr(ns, "variant", None):
+            extra += ["--variant", ns.variant]
+        if getattr(ns, "version", None):
+            extra += ["--version", ns.version]
+        if getattr(ns, "preview", False):
+            extra.append("--preview")
+        if getattr(ns, "force", False):
+            extra.append("--force")
+        res = _engine_stream("download", extra)
         out(res)
         if not res.get("ok"):
             raise SystemExit(1)
@@ -1028,10 +1061,40 @@ def build_parser() -> argparse.ArgumentParser:
         func=cmd_firmware
     )
 
-    fwf = fwsub.add_parser("flash", parents=[fw_sel, device_opts], help="Flash a built artifact")
+    fwf = fwsub.add_parser("flash", parents=[fw_sel, device_opts], help="Flash a built or downloaded artifact")
     fwf.add_argument("--artifact", help="Explicit firmware file (else last build)")
+    fwf.add_argument("--family", default="", help="MCU family for flash offset (download mode)")
     fwf.add_argument("--erase", action="store_true", help="esp32: erase flash first")
     fwf.set_defaults(func=cmd_firmware)
+
+    fwdt = fwsub.add_parser(
+        "download-tree", help="Official firmware catalog (Thonny JSON → micropython.org)"
+    )
+    fwdt.add_argument("--force", action="store_true", help="Refresh catalog cache")
+    fwdt.set_defaults(func=cmd_firmware)
+
+    fwdlist = fwsub.add_parser("download-list", help="List downloadable versions for a board")
+    fwdlist.add_argument("--board", required=True)
+    fwdlist.add_argument(
+        "--variant",
+        default="",
+        help="MP board variant (e.g. C6_WIFI)",
+    )
+    fwdlist.add_argument("--preview", action="store_true", help="Probe board page for latest preview")
+    fwdlist.add_argument("--force", action="store_true")
+    fwdlist.set_defaults(func=cmd_firmware)
+
+    fwdd = fwsub.add_parser("download", help="Download official firmware for a board")
+    fwdd.add_argument("--board", required=True)
+    fwdd.add_argument(
+        "--variant",
+        default="",
+        help="MP board variant (e.g. C6_WIFI)",
+    )
+    fwdd.add_argument("--version", default="", help="Release version (e.g. 1.28.0)")
+    fwdd.add_argument("--preview", action="store_true", help="Latest preview build")
+    fwdd.add_argument("--force", action="store_true", help="Refresh catalog cache")
+    fwdd.set_defaults(func=cmd_firmware)
 
     fwd = fwsub.add_parser("detect", parents=[fw_sel, device_opts],
                            help="esptool-first chip/flash/security probe")

--- a/python/sidecar.py
+++ b/python/sidecar.py
@@ -219,7 +219,10 @@ class Session:
         import serial.tools.list_ports
 
         ports = []
-        for p in sorted(serial.tools.list_ports.comports(), key=lambda x: x.device):
+        for p in serial.tools.list_ports.comports():
+            iface = getattr(p, "interface", None) or ""
+            # CircuitPython CDC2 is the data interface, not the REPL.
+            repl = "CircuitPython CDC2" not in iface
             ports.append(
                 {
                     "device": p.device,
@@ -229,8 +232,13 @@ class Session:
                     "manufacturer": p.manufacturer,
                     "product": p.product,
                     "description": p.description,
+                    "interface": iface or None,
+                    "hwid": getattr(p, "hwid", None) or None,
+                    "repl": repl,
                 }
             )
+        # REPL-capable first, then by device name; CDC2 (repl=false) last.
+        ports.sort(key=lambda x: (0 if x.get("repl", True) else 1, x["device"] or ""))
         return ports
 
     def connect(
@@ -260,12 +268,12 @@ class Session:
                     if not last:
                         time.sleep(retry_delay)
                         continue
-                    raise RuntimeError(str(e.args[0] if e.args else e)) from e
+                    raise RuntimeError(self._friendly_port_open_error(device, e)) from e
                 except OSError as e:
                     if not last:
                         time.sleep(retry_delay)
                         continue
-                    raise RuntimeError(f"failed to access {device}: {e}") from e
+                    raise RuntimeError(self._friendly_port_open_error(device, e)) from e
                 # Opening the COM port succeeds in UF2/bootloader mode too — require a
                 # MicroPython raw-REPL handshake before we report connected.
                 try:
@@ -282,8 +290,7 @@ class Session:
                         continue
                     self.device = None
                     raise RuntimeError(
-                        f"{device} is not responding as MicroPython "
-                        f"(likely bootloader/UF2 mode, wrong port, or busy REPL): {e}"
+                        self._friendly_probe_error(device, e)
                     ) from e
                 self.device = device
                 self.last_device = device
@@ -357,6 +364,41 @@ class Session:
         except Exception:
             pass
 
+    def _reset_esp_to_app(self, serial: Any) -> None:
+        """Pulse EN while IO0 is released so the chip boots firmware (not ROM download).
+
+        esptool Detect/flash leave many ESP boards in ``waiting for download``;
+        Connect must recover without requiring a physical RESET button.
+        """
+        import time
+
+        try:
+            serial.dtr = False  # IO0 released (not held for download)
+            serial.rts = True  # EN low
+            time.sleep(0.1)
+            serial.rts = False  # EN high → boot app
+            time.sleep(0.05)
+        except Exception:
+            try:
+                serial.setDTR(False)
+                serial.setRTS(True)
+                time.sleep(0.1)
+                serial.setRTS(False)
+            except Exception:
+                pass
+        time.sleep(1.6)  # USB-UART boards need time for ROM + MP boot banner
+        self._serial_flush(serial)
+
+    def _serial_peek(self, serial: Any, wait: float = 0.15) -> bytes:
+        import time
+
+        time.sleep(wait)
+        try:
+            n = serial.inWaiting()
+            return serial.read(n) if n else b""
+        except Exception:
+            return b""
+
     def _take_control(
         self, t: Any, *, clean: bool = True, timeout_overall: float = 20.0
     ) -> None:
@@ -378,18 +420,39 @@ class Session:
             except Exception:
                 pass
 
-        # Thorough interrupt before raw mode (see micropython#7867 / Thonny pipkin).
-        for delay in (0.0, 0.1, 0.1, 0.2):
-            if delay:
-                time.sleep(delay)
-            ctrl_c()
-        time.sleep(0.05)
-        self._serial_flush(serial)
+        def interrupt_storm() -> None:
+            # Thorough interrupt (see micropython#7867 / Thonny pipkin).
+            # Busy timer/display loops (common on P4 boards) need a longer storm.
+            for delay in (0.0, 0.05, 0.05, 0.1, 0.1, 0.15, 0.2):
+                if delay:
+                    time.sleep(delay)
+                ctrl_c()
+            time.sleep(0.05)
+            self._serial_flush(serial)
+
+        # If a prior esptool session left the chip in ROM download mode, reboot
+        # into firmware before trying the raw-REPL handshake.
+        peek = self._serial_peek(serial, 0.2)
+        if b"waiting for download" in peek or b"DOWNLOAD(" in peek:
+            self._reset_esp_to_app(serial)
+
+        interrupt_storm()
 
         last_err: Optional[Exception] = None
-        attempts = 4
-        per = max(5.0, float(timeout_overall) / attempts)
-        for attempt in range(attempts):
+        # Two short tries, then one app-mode reset (covers silent download mode
+        # where the banner was already drained), then two more tries.
+        schedule = [
+            ("try", 3.5),
+            ("try", 3.5),
+            ("reset", 0.0),
+            ("try", 5.0),
+            ("try", 5.0),
+        ]
+        for action, per in schedule:
+            if action == "reset":
+                self._reset_esp_to_app(serial)
+                interrupt_storm()
+                continue
             try:
                 t.enter_raw_repl(soft_reset=clean, timeout_overall=per)
                 return
@@ -399,9 +462,9 @@ class Session:
                     t.in_raw_repl = False
                 except Exception:
                     pass
-                ctrl_c()
-                ctrl_c()
-                time.sleep(0.15 + 0.1 * attempt)
+                for _ in range(4):
+                    ctrl_c()
+                    time.sleep(0.08)
                 self._serial_flush(serial)
                 try:
                     serial.write(b"\r\x01")  # poke raw REPL (Thonny)
@@ -410,9 +473,62 @@ class Session:
                 time.sleep(0.1)
 
         detail = str(last_err.args[0] if last_err and getattr(last_err, "args", None) else last_err)
-        raise RuntimeError(
-            f"could not take control of MicroPython (interrupt/raw REPL failed): {detail}"
-        ) from last_err
+        raise RuntimeError(self._friendly_take_control_error(detail)) from last_err
+
+    @staticmethod
+    def _friendly_port_open_error(device: str, exc: BaseException) -> str:
+        raw = str(exc.args[0] if getattr(exc, "args", None) else exc)
+        low = raw.lower()
+        locked = (
+            "exclusively lock" in low
+            or "exclusive" in low and "lock" in low
+            or "permissionerror" in low
+            or "access is denied" in low
+            or "permission denied" in low
+            or "failed to access" in low
+            or "busy" in low
+        )
+        if locked:
+            return (
+                f"failed to open {device}: port is busy or locked. "
+                f"Close Thonny, a serial monitor, another mpftp session, or any tool "
+                f"holding the port, then try again. ({raw})"
+            )
+        return f"failed to access {device}: {raw}"
+
+    @staticmethod
+    def _friendly_take_control_error(detail: str) -> str:
+        return (
+            f"could not take control of MicroPython (interrupt/raw REPL failed): {detail}\n"
+            f"Device is busy or does not respond. Your options:\n"
+            f"  - wait until it completes current work;\n"
+            f"  - hard-reset the board and try again;\n"
+            f"  - check for a runaway main.py (rename/remove it if it blocks the REPL);\n"
+            f"  - confirm firmware is MicroPython (not bootloader/UF2);\n"
+            f"  - close other serial tools holding the port."
+        )
+
+    @staticmethod
+    def _friendly_probe_error(device: str, exc: BaseException) -> str:
+        detail = str(exc.args[0] if getattr(exc, "args", None) else exc)
+        base = (
+            f"{device} is not responding as MicroPython "
+            f"(likely bootloader/UF2 mode, wrong port, or busy REPL): {detail}"
+        )
+        # Take-control failures already include the checklist.
+        if "could not take control" in detail or "Your options:" in detail:
+            return base
+        return (
+            f"{base}\n"
+            f"  - wait / hard-reset / check main.py / confirm MicroPython / close other tools."
+        )
+
+    def _sync_remote_fs(self, t: Any) -> None:
+        """Flush on-board filesystem after writes (mpremote fs_writefile does not sync)."""
+        try:
+            t.exec("import os\nif hasattr(os, 'sync'):\n os.sync()")
+        except Exception:
+            pass
 
     def _probe_micropython(self, t: Any) -> Optional[list[int]]:
         """Take control (interrupt + raw soft-reset), set RTC, leave raw REPL.
@@ -542,6 +658,7 @@ class Session:
 
         def op(t):
             t.fs_writefile(path, data)
+            self._sync_remote_fs(t)
             return {"path": path, "size": len(data)}
 
         return self.with_raw(op)
@@ -1125,6 +1242,8 @@ print(repr(rows))
                 if hx != host_sha256(data):
                     raise RuntimeError(f"hash mismatch after upload: {final}")
                 verified.append(final)
+        if copied:
+            self._sync_remote_fs(t)
 
     def _cp_remote_to_local(
         self, t, src: str, dest: str, verify: bool, copied: list[str], verified: list[str]

--- a/python/tests/fixtures/micropython-variants-esptool.json
+++ b/python/tests/fixtures/micropython-variants-esptool.json
@@ -1,0 +1,63 @@
+[
+  {
+    "vendor": "Arduino",
+    "model": "Nano ESP32",
+    "family": "esp32s3",
+    "info_url": "https://micropython.org/download/ARDUINO_NANO_ESP32",
+    "downloads": [
+      {
+        "version": "1.28.0",
+        "url": "https://micropython.org/resources/firmware/ARDUINO_NANO_ESP32-20260406-v1.28.0.bin"
+      },
+      {
+        "version": "1.27.0",
+        "url": "https://micropython.org/resources/firmware/ARDUINO_NANO_ESP32-20251209-v1.27.0.bin"
+      }
+    ],
+    "latest_prerelease_regex": "\\d{8}-v1.29.0-preview\\.\\d+\\.[a-z0-9]{10}"
+  },
+  {
+    "vendor": "Espressif",
+    "model": "ESP32 / WROOM",
+    "family": "esp32",
+    "info_url": "https://micropython.org/download/ESP32_GENERIC",
+    "downloads": [
+      {
+        "version": "1.28.0",
+        "url": "https://micropython.org/resources/firmware/ESP32_GENERIC-20260406-v1.28.0.bin"
+      },
+      {
+        "version": "1.27.0",
+        "url": "https://micropython.org/resources/firmware/ESP32_GENERIC-20251209-v1.27.0.bin"
+      }
+    ]
+  },
+  {
+    "vendor": "Espressif",
+    "model": "ESP32-S3",
+    "family": "esp32s3",
+    "info_url": "https://micropython.org/download/ESP32_GENERIC_S3",
+    "downloads": [
+      {
+        "version": "1.28.0",
+        "url": "https://micropython.org/resources/firmware/ESP32_GENERIC_S3-20260406-v1.28.0.bin"
+      },
+      {
+        "version": "1.27.0",
+        "url": "https://micropython.org/resources/firmware/ESP32_GENERIC_S3-20251209-v1.27.0.bin"
+      }
+    ]
+  },
+  {
+    "vendor": "Espressif",
+    "model": "ESP32-P4",
+    "family": "esp32p4",
+    "info_url": "https://micropython.org/download/ESP32_GENERIC_P4",
+    "downloads": [
+      {
+        "version": "1.28.0",
+        "url": "https://micropython.org/resources/firmware/ESP32_GENERIC_P4-20260406-v1.28.0.bin"
+      }
+    ]
+  }
+]

--- a/python/tests/fixtures/micropython-variants-uf2.json
+++ b/python/tests/fixtures/micropython-variants-uf2.json
@@ -1,0 +1,83 @@
+[
+  {
+    "vendor": "Adafruit",
+    "model": "Feather M0 Express",
+    "family": "samd21",
+    "info_url": "https://micropython.org/download/ADAFRUIT_FEATHER_M0_EXPRESS",
+    "downloads": [
+      {
+        "version": "1.28.0",
+        "url": "https://micropython.org/resources/firmware/ADAFRUIT_FEATHER_M0_EXPRESS-20260406-v1.28.0.uf2"
+      },
+      {
+        "version": "1.27.0",
+        "url": "https://micropython.org/resources/firmware/ADAFRUIT_FEATHER_M0_EXPRESS-20251209-v1.27.0.uf2"
+      }
+    ],
+    "latest_prerelease_regex": "\\d{8}-v1.29.0-preview\\.\\d+\\.[a-z0-9]{10}"
+  },
+  {
+    "vendor": "Adafruit",
+    "model": "Feather RP2040",
+    "family": "rp2",
+    "info_url": "https://micropython.org/download/ADAFRUIT_FEATHER_RP2040",
+    "downloads": [
+      {
+        "version": "1.28.0",
+        "url": "https://micropython.org/resources/firmware/ADAFRUIT_FEATHER_RP2040-20260406-v1.28.0.uf2"
+      },
+      {
+        "version": "1.27.0",
+        "url": "https://micropython.org/resources/firmware/ADAFRUIT_FEATHER_RP2040-20251209-v1.27.0.uf2"
+      }
+    ]
+  },
+  {
+    "vendor": "Adafruit",
+    "model": "ItsyBitsy M0 Express",
+    "family": "samd21",
+    "info_url": "https://micropython.org/download/ADAFRUIT_ITSYBITSY_M0_EXPRESS",
+    "downloads": [
+      {
+        "version": "1.28.0",
+        "url": "https://micropython.org/resources/firmware/ADAFRUIT_ITSYBITSY_M0_EXPRESS-20260406-v1.28.0.uf2"
+      },
+      {
+        "version": "1.27.0",
+        "url": "https://micropython.org/resources/firmware/ADAFRUIT_ITSYBITSY_M0_EXPRESS-20251209-v1.27.0.uf2"
+      }
+    ]
+  },
+  {
+    "vendor": "Adafruit",
+    "model": "ItsyBitsy RP2040",
+    "family": "rp2",
+    "info_url": "https://micropython.org/download/ADAFRUIT_ITSYBITSY_RP2040",
+    "downloads": [
+      {
+        "version": "1.28.0",
+        "url": "https://micropython.org/resources/firmware/ADAFRUIT_ITSYBITSY_RP2040-20260406-v1.28.0.uf2"
+      },
+      {
+        "version": "1.27.0",
+        "url": "https://micropython.org/resources/firmware/ADAFRUIT_ITSYBITSY_RP2040-20251209-v1.27.0.uf2"
+      }
+    ]
+  },
+  {
+    "vendor": "Adafruit",
+    "model": "NeoKey Trinkey",
+    "family": "samd21",
+    "info_url": "https://micropython.org/download/ADAFRUIT_NEOKEY_TRINKEY",
+    "downloads": [
+      {
+        "version": "1.28.0",
+        "url": "https://micropython.org/resources/firmware/ADAFRUIT_NEOKEY_TRINKEY-20260406-v1.28.0.uf2"
+      },
+      {
+        "version": "1.27.0",
+        "url": "https://micropython.org/resources/firmware/ADAFRUIT_NEOKEY_TRINKEY-20251209-v1.27.0.uf2"
+      }
+    ]
+  }
+]

--- a/python/tests/test_firmware_download.py
+++ b/python/tests/test_firmware_download.py
@@ -1,0 +1,184 @@
+"""Unit tests for firmware_download (no network — fixtures + fake fetch)."""
+
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from firmware_download import (
+    board_id_from_info_url,
+    catalog_tree,
+    find_variant,
+    list_board,
+    list_downloads,
+    load_catalog,
+    maybe_latest_preview,
+    normalize_flash_offset,
+    normalize_variant,
+    parse_board_page_firmware,
+    pick_download,
+    port_for_family,
+    resolve_remote_flash_offset,
+)
+
+FIXTURES = Path(__file__).resolve().parent / "fixtures"
+
+
+def _fixture_fetch(url: str, timeout: float = 30.0) -> str:
+    if url.endswith("micropython-variants-esptool.json"):
+        return (FIXTURES / "micropython-variants-esptool.json").read_text("utf-8")
+    if url.endswith("micropython-variants-uf2.json"):
+        return (FIXTURES / "micropython-variants-uf2.json").read_text("utf-8")
+    if url.endswith("/ESP32_GENERIC_P4/board.json"):
+        return json.dumps(
+            {
+                "mcu": "esp32p4",
+                "deploy_options": {"flash_offset": "0x2000"},
+            }
+        )
+    if url.endswith("/ESP32_GENERIC/board.json"):
+        return json.dumps(
+            {
+                "mcu": "esp32",
+                "deploy_options": {"flash_offset": "0x1000"},
+            }
+        )
+    if "ESP32_GENERIC_P4" in url:
+        return """
+        <html><body>
+        <a href="/resources/firmware/ESP32_GENERIC_P4-20260406-v1.28.0.bin">bin</a>
+        <a href="/resources/firmware/ESP32_GENERIC_P4-C6_WIFI-20260406-v1.28.0.bin">bin</a>
+        <a href="/resources/firmware/ESP32_GENERIC_P4-C5_WIFI-20260406-v1.28.0.bin">bin</a>
+        <a href="/resources/firmware/ESP32_GENERIC_P4-C6_WIFI-20260717-v1.29.0-preview.100.gabcdef0123.bin">bin</a>
+        </body></html>
+        """
+    if "ESP32_GENERIC" in url and "download" in url:
+        return """
+        <html><body>
+        <a href="/resources/firmware/ESP32_GENERIC-20260717-v1.29.0-preview.590.g772df1ae57.bin">bin</a>
+        </body></html>
+        """
+    raise RuntimeError(f"unexpected fetch url in test: {url}")
+
+
+class NormalizeTests(unittest.TestCase):
+    def test_board_id(self):
+        self.assertEqual(
+            board_id_from_info_url("https://micropython.org/download/ESP32_GENERIC"),
+            "ESP32_GENERIC",
+        )
+
+    def test_port_for_family(self):
+        self.assertEqual(port_for_family("esp32s3"), "esp32")
+        self.assertEqual(port_for_family("rp2"), "rp2")
+        self.assertEqual(port_for_family("samd21"), "samd")
+
+    def test_normalize(self):
+        raw = json.loads((FIXTURES / "micropython-variants-esptool.json").read_text())[1]
+        v = normalize_variant(raw)
+        self.assertEqual(v["board"], "ESP32_GENERIC")
+        self.assertEqual(v["port"], "esp32")
+        self.assertTrue(v["downloads"])
+
+
+class CatalogTests(unittest.TestCase):
+    def setUp(self):
+        self._td = tempfile.TemporaryDirectory()
+        self.addCleanup(self._td.cleanup)
+        self.patcher = mock.patch("firmware_download.CACHE_ROOT", Path(self._td.name))
+        self.patcher.start()
+        self.addCleanup(self.patcher.stop)
+
+    def test_load_and_tree(self):
+        cat = load_catalog(fetch=_fixture_fetch, force=True)
+        self.assertTrue(any(v["board"] == "ESP32_GENERIC" for v in cat))
+        self.assertTrue(any(v["port"] == "rp2" for v in cat))
+        tree = catalog_tree(cat)
+        ports = {p["port"] for p in tree["ports"]}
+        self.assertIn("esp32", ports)
+        self.assertIn("rp2", ports)
+
+    def test_find_and_list(self):
+        cat = load_catalog(fetch=_fixture_fetch, force=True)
+        v = find_variant("ESP32_GENERIC", catalog=cat)
+        self.assertIsNotNone(v)
+        assert v is not None
+        dls = list_downloads(v)
+        self.assertTrue(any(d["channel"] == "release" for d in dls))
+        info = list_board("ESP32_GENERIC", catalog=cat, fetch=_fixture_fetch)
+        self.assertEqual(info["board"], "ESP32_GENERIC")
+
+    def test_pick_latest_release(self):
+        cat = load_catalog(fetch=_fixture_fetch, force=True)
+        v = find_variant("ESP32_GENERIC", catalog=cat)
+        assert v is not None
+        chosen = pick_download(v)
+        self.assertEqual(chosen["channel"], "release")
+        self.assertIn("1.28.0", chosen["version"])
+
+    def test_preview_from_page(self):
+        cat = load_catalog(fetch=_fixture_fetch, force=True)
+        v = find_variant("ESP32_GENERIC", catalog=cat)
+        assert v is not None
+        # Inject regex like Thonny does for some boards.
+        v = dict(v)
+        v["latest_prerelease_regex"] = r"\d{8}-v1\.29\.0-preview\.\d+\.[a-z0-9]{10}"
+        prev = maybe_latest_preview(v, fetch=_fixture_fetch)
+        self.assertIsNotNone(prev)
+        assert prev is not None
+        self.assertEqual(prev["channel"], "preview")
+        self.assertIn("preview", prev["url"])
+
+    def test_p4_c6_wifi_variant(self):
+        cat = load_catalog(fetch=_fixture_fetch, force=True)
+        v = find_variant("ESP32_GENERIC_P4", catalog=cat)
+        assert v is not None
+        info = list_board(
+            "ESP32_GENERIC_P4",
+            mp_variant="C6_WIFI",
+            catalog=cat,
+            fetch=_fixture_fetch,
+        )
+        self.assertIn("C6_WIFI", info["variants"])
+        self.assertIn("C5_WIFI", info["variants"])
+        self.assertTrue(info["downloads"])
+        self.assertTrue(
+            all("C6_WIFI" in d["url"] for d in info["downloads"])
+        )
+        chosen = pick_download(v, mp_variant="C6_WIFI", fetch=_fixture_fetch)
+        self.assertEqual(chosen["channel"], "release")
+        self.assertIn("C6_WIFI", chosen["url"])
+        self.assertNotIn("C5_WIFI", chosen["url"])
+        preview = pick_download(
+            v, mp_variant="C6_WIFI", preview=True, fetch=_fixture_fetch
+        )
+        self.assertEqual(preview["channel"], "preview")
+        self.assertIn("C6_WIFI", preview["url"])
+
+    def test_parse_board_page_groups_variants(self):
+        html = _fixture_fetch("https://micropython.org/download/ESP32_GENERIC_P4/")
+        grouped = parse_board_page_firmware("ESP32_GENERIC_P4", html)
+        self.assertIn("", grouped)
+        self.assertIn("C6_WIFI", grouped)
+        self.assertIn("C5_WIFI", grouped)
+
+    def test_remote_board_json_flash_offset(self):
+        self.assertEqual(normalize_flash_offset("0"), "0x0")
+        self.assertEqual(normalize_flash_offset("0x2000"), "0x2000")
+        off = resolve_remote_flash_offset(
+            "ESP32_GENERIC_P4", port="esp32", fetch=_fixture_fetch, force=True
+        )
+        self.assertEqual(off, "0x2000")
+        info = list_board(
+            "ESP32_GENERIC_P4",
+            catalog=load_catalog(fetch=_fixture_fetch, force=True),
+            fetch=_fixture_fetch,
+        )
+        self.assertEqual(info.get("flashOffset"), "0x2000")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/agent/AgentRpcServer.ts
+++ b/src/agent/AgentRpcServer.ts
@@ -223,10 +223,44 @@ export class AgentRpcServer {
           {
             ...pathArgs,
             ...sel,
+            family: (params.family as string) || undefined,
             device: (params.device as string) || "",
             artifact: (params.artifact as string) || undefined,
             erase: !!params.erase,
             esptool: this.firmware.esptoolCommand() || undefined,
+          },
+          (line) => {
+            if (log.length < 4000) {
+              log.push(line);
+            }
+          }
+        );
+        const result = await handle.done;
+        return { ...result, log };
+      }
+      case "download_tree":
+      case "download-tree":
+        return this.firmware.run("download-tree", {
+          force: params.force ? true : undefined,
+        });
+      case "download_list":
+      case "download-list":
+        return this.firmware.run("download-list", {
+          board: (params.board as string) || sel.board,
+          variant: (params.variant as string) || sel.variant || undefined,
+          preview: params.preview ? true : undefined,
+          force: params.force ? true : undefined,
+        });
+      case "download": {
+        const log: string[] = [];
+        const handle = this.firmware.stream(
+          "download",
+          {
+            board: (params.board as string) || sel.board,
+            variant: (params.variant as string) || sel.variant || undefined,
+            version: (params.version as string) || undefined,
+            preview: params.preview ? true : undefined,
+            force: params.force ? true : undefined,
           },
           (line) => {
             if (log.length < 4000) {

--- a/src/bridge/SidecarBridge.ts
+++ b/src/bridge/SidecarBridge.ts
@@ -3,7 +3,14 @@ import * as path from "path";
 import { EventEmitter } from "events";
 import * as vscode from "vscode";
 import { ActivityLog, summarizeParams } from "../activityLog";
-import { getConfig, pathForPythonProcess, resolvePython } from "../platform";
+import {
+  GS_LAST_DEVICE,
+  GS_LAST_VIDPID,
+  getConfig,
+  pathForPythonProcess,
+  portVidPidKey,
+  resolvePython,
+} from "../platform";
 
 export type PortInfo = {
   device: string;
@@ -13,6 +20,10 @@ export type PortInfo = {
   manufacturer?: string | null;
   product?: string | null;
   description?: string | null;
+  interface?: string | null;
+  hwid?: string | null;
+  /** false for CircuitPython CDC2 (data) interfaces — not for REPL connect. */
+  repl?: boolean;
 };
 
 export type DirEntry = {
@@ -42,7 +53,8 @@ export class SidecarBridge extends EventEmitter {
   constructor(
     private readonly extensionPath: string,
     private readonly log: vscode.OutputChannel,
-    private readonly activity?: ActivityLog
+    private readonly activity?: ActivityLog,
+    private readonly globalState?: vscode.Memento
   ) {
     super();
   }
@@ -57,6 +69,35 @@ export class SidecarBridge extends EventEmitter {
 
   get connected(): boolean {
     return !!this._connectedDevice;
+  }
+
+  /** Seed in-memory last device from globalState (after window reload). */
+  seedLastDeviceFromGlobalState(): void {
+    const saved = this.globalState?.get<string>(GS_LAST_DEVICE);
+    if (saved && !this._lastDevice) {
+      this._lastDevice = saved;
+    }
+  }
+
+  get rememberedVidPid(): string | undefined {
+    return this.globalState?.get<string>(GS_LAST_VIDPID);
+  }
+
+  private async persistLastDevice(device: string): Promise<void> {
+    if (!this.globalState) {
+      return;
+    }
+    await this.globalState.update(GS_LAST_DEVICE, device);
+    try {
+      const ports = await this.listPorts();
+      const match = ports.find((p) => p.device === device);
+      const key = match ? portVidPidKey(match) : undefined;
+      if (key) {
+        await this.globalState.update(GS_LAST_VIDPID, key);
+      }
+    } catch {
+      /* port list optional for persistence */
+    }
   }
 
   async ensureStarted(): Promise<void> {
@@ -233,6 +274,7 @@ export class SidecarBridge extends EventEmitter {
     await this.request("connect", { device, baud: baud ?? cfg.defaultBaud });
     this._connectedDevice = device;
     this._lastDevice = device;
+    await this.persistLastDevice(device);
     await vscode.commands.executeCommand("setContext", "mpftp.connected", true);
     this.activity?.event("connected", { message: device, data: { device } });
     // `silent` reconnects (e.g. after detect/flash) restore the link without
@@ -240,8 +282,14 @@ export class SidecarBridge extends EventEmitter {
     this.emit("connected", device, { silent: !!opts?.silent });
   }
 
-  /** Reconnect to the last device (after hard-reset / port flicker). */
+  /** Reconnect to the last device (after hard-reset / port flicker / reload). */
   async resume(baud?: number): Promise<void> {
+    // After a window reload the sidecar is fresh (no last_device); use
+    // in-memory / globalState last device and connect directly.
+    if (!this._connectedDevice && this._lastDevice) {
+      await this.connect(this._lastDevice, baud);
+      return;
+    }
     const cfg = getConfig();
     const res = await this.request<{ device: string }>("resume", {
       baud: baud ?? cfg.defaultBaud,
@@ -252,6 +300,7 @@ export class SidecarBridge extends EventEmitter {
     }
     this._connectedDevice = device;
     this._lastDevice = device;
+    await this.persistLastDevice(device);
     await vscode.commands.executeCommand("setContext", "mpftp.connected", true);
     this.activity?.event("connected", { message: `resume ${device}`, data: { device } });
     this.emit("connected", device);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,12 @@ import { openBoardFileInEditor, registerEditSaveHook } from "./editRemote";
 import { openRepl } from "./terminal/ReplTerminal";
 import { FtpViewProvider } from "./webview/FtpViewProvider";
 import { FirmwarePanel } from "./firmware/FirmwarePanel";
-import { detectHost, getConfig, resolvePython } from "./platform";
+import {
+  detectHost,
+  filterAndSortPorts,
+  getConfig,
+  resolvePython,
+} from "./platform";
 
 let bridge: SidecarBridge;
 let log: vscode.OutputChannel;
@@ -19,7 +24,8 @@ let statusBar: vscode.StatusBarItem;
 export async function activate(context: vscode.ExtensionContext): Promise<void> {
   log = vscode.window.createOutputChannel("mpftp");
   activity = new ActivityLog();
-  bridge = new SidecarBridge(context.extensionPath, log, activity);
+  bridge = new SidecarBridge(context.extensionPath, log, activity, context.globalState);
+  bridge.seedLastDeviceFromGlobalState();
   agentRpc = new AgentRpcServer(bridge, activity, context.extensionPath);
   agentRpc.start();
 
@@ -69,7 +75,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
     );
 
-    const ports = await bridge.listPorts();
+    const ports = filterAndSortPorts(await bridge.listPorts(), {
+      lastDevice: bridge.lastDevice,
+      lastVidPid: bridge.rememberedVidPid,
+    });
     const items = ports.map((p) => portQuickPick(p));
     if (!items.length) {
       const host = detectHost();
@@ -84,10 +93,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     const cfg = getConfig();
     let device = cfg.autoConnectDevice;
     if (!device) {
-      const pick = await vscode.window.showQuickPick(items, {
-        title: "Select MicroPython board",
-        placeHolder: "Serial port",
-      });
+      // Last-good port is sorted first; preselect it in the quick pick.
+      const pick = await showPortQuickPick(items, "Select MicroPython board");
       if (!pick) {
         return;
       }
@@ -437,17 +444,51 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   }
 }
 
-function portQuickPick(p: PortInfo) {
+type PortPickItem = vscode.QuickPickItem & { device: string };
+
+function portQuickPick(p: PortInfo): PortPickItem {
   const vidpid =
     p.vid != null && p.pid != null
       ? `${p.vid.toString(16).padStart(4, "0")}:${p.pid.toString(16).padStart(4, "0")}`
       : "";
+  const detailParts = [p.interface, p.serial_number || p.description].filter(Boolean);
   return {
     label: p.device,
     description: [p.product, p.manufacturer, vidpid].filter(Boolean).join(" · "),
-    detail: p.serial_number || p.description || undefined,
+    detail: detailParts.length ? detailParts.join(" · ") : undefined,
     device: p.device,
   };
+}
+
+function showPortQuickPick(
+  items: PortPickItem[],
+  title: string
+): Promise<PortPickItem | undefined> {
+  return new Promise((resolve) => {
+    const qp = vscode.window.createQuickPick<PortPickItem>();
+    let settled = false;
+    const finish = (value: PortPickItem | undefined) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      qp.dispose();
+      resolve(value);
+    };
+    qp.title = title;
+    qp.placeholder = "Serial port";
+    qp.items = items;
+    if (items.length) {
+      qp.activeItems = [items[0]];
+    }
+    qp.onDidAccept(() => {
+      finish(qp.selectedItems[0]);
+    });
+    qp.onDidHide(() => {
+      finish(undefined);
+    });
+    qp.show();
+  });
 }
 
 function updateStatus(): void {

--- a/src/firmware/FirmwarePanel.ts
+++ b/src/firmware/FirmwarePanel.ts
@@ -4,7 +4,7 @@ import * as path from "path";
 import * as vscode from "vscode";
 import { ActivityLog } from "../activityLog";
 import { SidecarBridge } from "../bridge/SidecarBridge";
-import { detectHost, getConfig } from "../platform";
+import { detectHost, filterAndSortPorts, getConfig } from "../platform";
 import { FirmwareEngine, StreamHandle } from "./engine";
 
 interface Selection {
@@ -17,6 +17,11 @@ interface Prefs {
   reconnectAfterFlash: boolean;
   alsoFlashAfterBuild: boolean;
   device: string;
+  /** Explicit source — never inferred from MicroPython checkout presence. */
+  firmwareSource: "build" | "download";
+  /** Empty = latest stable release from catalog. */
+  downloadVersion: string;
+  downloadPreview: boolean;
 }
 
 /** Structured "toolchain missing" payload emitted by the build engine. */
@@ -41,10 +46,22 @@ export class FirmwarePanel {
   private readonly engine: FirmwareEngine;
   private discovery: Record<string, unknown> = {};
   private tree: any[] = [];
+  private downloadTree: any[] = [];
   private cmods: Record<string, unknown> = {};
   private flashers: Record<string, string> = {};
   private selection: Selection = { port: "", board: "", variant: "" };
-  private prefs: Prefs = { reconnectAfterFlash: false, alsoFlashAfterBuild: false, device: "" };
+  /** MCU family from download catalog (for flash offset). */
+  private downloadFamily = "";
+  private downloadVersions: Array<{ version: string; channel: string; url: string }> = [];
+  private downloadedArtifact: Record<string, unknown> | undefined;
+  private prefs: Prefs = {
+    reconnectAfterFlash: false,
+    alsoFlashAfterBuild: false,
+    device: "",
+    firmwareSource: "build",
+    downloadVersion: "",
+    downloadPreview: false,
+  };
   private activeStream: StreamHandle | undefined;
   private busy = false;
   private lastDetect: Record<string, unknown> | undefined;
@@ -105,6 +122,15 @@ export class FirmwarePanel {
       if (typeof s.alsoFlashAfterBuild === "boolean") {
         this.prefs.alsoFlashAfterBuild = s.alsoFlashAfterBuild;
       }
+      if (s.firmwareSource === "build" || s.firmwareSource === "download") {
+        this.prefs.firmwareSource = s.firmwareSource;
+      }
+      if (typeof s.downloadVersion === "string") {
+        this.prefs.downloadVersion = s.downloadVersion;
+      }
+      if (typeof s.downloadPreview === "boolean") {
+        this.prefs.downloadPreview = s.downloadPreview;
+      }
     } catch {
       /* first run */
     }
@@ -121,6 +147,9 @@ export class FirmwarePanel {
     s.lastDevice = this.prefs.device;
     s.reconnectAfterFlash = this.prefs.reconnectAfterFlash;
     s.alsoFlashAfterBuild = this.prefs.alsoFlashAfterBuild;
+    s.firmwareSource = this.prefs.firmwareSource;
+    s.downloadVersion = this.prefs.downloadVersion;
+    s.downloadPreview = this.prefs.downloadPreview;
     try {
       fs.mkdirSync(path.dirname(STATE_FILE), { recursive: true });
       fs.writeFileSync(STATE_FILE, JSON.stringify(s, null, 2), "utf8");
@@ -204,7 +233,12 @@ export class FirmwarePanel {
           board: msg.board || "",
           variant: msg.variant || "",
         };
+        this.downloadedArtifact = undefined;
         this.savePrefs();
+        if (this.prefs.firmwareSource === "download") {
+          await this.refreshDownloadList();
+          this.pushState();
+        }
         await this.refreshArtifact();
         break;
       case "build":
@@ -240,12 +274,36 @@ export class FirmwarePanel {
           this.prefs.reconnectAfterFlash = !!msg.value;
         } else if (msg.key === "alsoFlashAfterBuild") {
           this.prefs.alsoFlashAfterBuild = !!msg.value;
+        } else if (msg.key === "downloadVersion") {
+          this.prefs.downloadVersion = String(msg.value || "");
+          this.prefs.downloadPreview = false;
+        } else if (msg.key === "downloadPreview") {
+          this.prefs.downloadPreview = !!msg.value;
+          if (this.prefs.downloadPreview) {
+            this.prefs.downloadVersion = "";
+          }
         }
         this.savePrefs();
+        break;
+      case "setSource":
+        await this.setSource(msg.source === "download" ? "download" : "build");
+        break;
+      case "download":
+        await this.doDownload();
+        break;
+      case "browseArtifact":
+        await this.browseArtifact();
         break;
       default:
         break;
     }
+  }
+
+  private async setSource(source: "build" | "download"): Promise<void> {
+    this.prefs.firmwareSource = source;
+    this.downloadedArtifact = undefined;
+    this.savePrefs();
+    await this.refreshAll();
   }
 
   // ---------------------------------------------------------------------- //
@@ -258,32 +316,107 @@ export class FirmwarePanel {
     } catch (e: any) {
       this.log(`[mpftp] discover failed: ${e?.message || e}`);
     }
-    if (!this.mpDir()) {
-      this.pushState();
-      return;
-    }
-    try {
-      const t = await this.engine.run<{ ports: any[] }>("tree", this.pathArgs());
-      this.tree = t.ports || [];
-    } catch (e: any) {
-      this.log(`[mpftp] tree failed: ${e?.message || e}`);
-    }
-    try {
-      this.cmods = await this.engine.run("cmods", this.pathArgs());
-    } catch {
-      /* ignore */
-    }
     try {
       const f = await this.engine.run<{ flashers: Record<string, string> }>("flashers");
       this.flashers = f.flashers || {};
     } catch {
       /* ignore */
     }
-    // Auto-select from a connected device if we have no selection yet.
-    await this.autoSelectFromDevice();
+
+    if (this.prefs.firmwareSource === "download") {
+      try {
+        const t = await this.engine.run<{ ports: any[] }>("download-tree");
+        this.downloadTree = t.ports || [];
+        this.tree = this.downloadTree;
+      } catch (e: any) {
+        this.log(`[mpftp] download-tree failed: ${e?.message || e}`);
+        this.downloadTree = [];
+        this.tree = [];
+      }
+      this.cmods = {};
+      await this.refreshDownloadList();
+    } else {
+      if (!this.mpDir()) {
+        this.tree = [];
+        this.pushState();
+        await this.pushDevices();
+        return;
+      }
+      try {
+        const t = await this.engine.run<{ ports: any[] }>("tree", this.pathArgs());
+        this.tree = t.ports || [];
+      } catch (e: any) {
+        this.log(`[mpftp] tree failed: ${e?.message || e}`);
+      }
+      try {
+        this.cmods = await this.engine.run("cmods", this.pathArgs());
+      } catch {
+        /* ignore */
+      }
+      await this.autoSelectFromDevice();
+    }
+
     this.pushState();
     await this.refreshArtifact();
     await this.pushDevices();
+  }
+
+  private async refreshDownloadList(): Promise<void> {
+    this.downloadVersions = [];
+    this.downloadFamily = "";
+    if (!this.selection.board) {
+      return;
+    }
+    // Resolve family from tree entry.
+    for (const p of this.downloadTree) {
+      const b = (p.boards || []).find((x: any) => x.board === this.selection.board);
+      if (b) {
+        this.downloadFamily = b.family || "";
+        this.selection.port = p.port || this.selection.port;
+        break;
+      }
+    }
+    try {
+      const info = await this.engine.run<{
+        downloads?: Array<{ version: string; channel: string; url: string }>;
+        variants?: string[];
+        family?: string;
+        port?: string;
+        flashOffset?: string;
+      }>("download-list", {
+        board: this.selection.board,
+        variant: this.selection.variant || undefined,
+        preview: this.prefs.downloadPreview ? true : undefined,
+      });
+      this.downloadVersions = info.downloads || [];
+      if (info.family) {
+        this.downloadFamily = info.family;
+      }
+      if (info.port) {
+        this.selection.port = info.port;
+      }
+      // Attach scraped MP variants (C6_WIFI, …) so Target can expand them.
+      if (Array.isArray(info.variants)) {
+        for (const p of this.downloadTree) {
+          const b = (p.boards || []).find(
+            (x: any) => x.board === this.selection.board
+          );
+          if (b) {
+            b.variants = info.variants;
+            break;
+          }
+        }
+      }
+      // Prefill Flash offset from upstream board.json (e.g. P4 → 0x2000).
+      if (typeof info.flashOffset === "string" && info.flashOffset) {
+        this.post({
+          type: "flashOffsetDefault",
+          flashOffset: info.flashOffset,
+        });
+      }
+    } catch (e: any) {
+      this.log(`[mpftp] download-list failed: ${e?.message || e}`);
+    }
   }
 
   // ---------------------------------------------------------------------- //
@@ -367,6 +500,10 @@ export class FirmwarePanel {
       this.detectStatus("failed", "Detect failed");
     }
 
+    // esptool hard-resets the chip; give USB-UART boards time to finish boot
+    // before Connect's raw-REPL handshake (P4 + CH343 needs ~1.5–2s).
+    await new Promise((r) => setTimeout(r, 1800));
+
     if (wasConnected) {
       try {
         await this.bridge.connect(device, undefined, { silent: true });
@@ -383,6 +520,9 @@ export class FirmwarePanel {
     }
 
     this.post({ type: "detect", detect: this.lastDetect || null });
+    if (this.prefs.firmwareSource === "download") {
+      await this.refreshDownloadList();
+    }
     this.pushState();
     await this.refreshArtifact();
     await this.pushDevices();
@@ -505,11 +645,23 @@ export class FirmwarePanel {
       return;
     }
     if (conf === "matched" || conf === "family-only") {
-      this.selection = {
-        port,
-        board: String(m.board || ""),
-        variant: String(m.variant || ""),
-      };
+      let board = String(m.board || "");
+      const variant = String(m.variant || "");
+      if (this.prefs.firmwareSource === "download" && board) {
+        const inCatalog = this.downloadTree.some((p: any) =>
+          (p.boards || []).some((b: any) => b.board === board)
+        );
+        if (!inCatalog) {
+          this.log(
+            `[mpftp] detected board ${board} not in download catalog — pick Target or Browse local`
+          );
+          // Keep port; prefer a GENERIC board on that port if available.
+          const node = this.downloadTree.find((p: any) => p.port === port);
+          const generic = node?.boards?.find((x: any) => /GENERIC/.test(x.board));
+          board = generic?.board || "";
+        }
+      }
+      this.selection = { port, board, variant };
       this.savePrefs();
     }
   }
@@ -566,6 +718,19 @@ export class FirmwarePanel {
   }
 
   private async refreshArtifact(): Promise<void> {
+    if (this.prefs.firmwareSource === "download") {
+      const artVar = String(this.downloadedArtifact?.variant || "");
+      if (
+        this.downloadedArtifact?.ready &&
+        this.downloadedArtifact.board === this.selection.board &&
+        artVar === (this.selection.variant || "")
+      ) {
+        this.post({ type: "artifact", artifact: this.downloadedArtifact });
+      } else {
+        this.post({ type: "artifact", artifact: { ready: false } });
+      }
+      return;
+    }
     if (!this.selection.port || !this.mpDir()) {
       this.post({ type: "artifact", artifact: { ready: false } });
       return;
@@ -617,6 +782,8 @@ export class FirmwarePanel {
       flashers: this.flashers,
       selection: this.selection,
       prefs: this.prefs,
+      downloadVersions: this.downloadVersions,
+      downloadFamily: this.downloadFamily,
       connectedDevice: this.bridge.connectedDevice || "",
       detect: this.lastDetect || null,
       busy: this.busy,
@@ -816,6 +983,90 @@ export class FirmwarePanel {
   // Flash
   // ---------------------------------------------------------------------- //
 
+  private async doDownload(): Promise<void> {
+    if (this.busy) {
+      return;
+    }
+    if (!this.selection.board) {
+      void vscode.window.showWarningMessage("Select a board in Target first.");
+      return;
+    }
+    this.busy = true;
+    this.phase("building", "Downloading…");
+    this.post({ type: "clearLog" });
+    const handle = this.engine.stream(
+      "download",
+      {
+        board: this.selection.board,
+        variant: this.selection.variant || undefined,
+        version: this.prefs.downloadPreview
+          ? undefined
+          : this.prefs.downloadVersion || undefined,
+        preview: this.prefs.downloadPreview ? true : undefined,
+      },
+      (line) => this.log(line)
+    );
+    this.activeStream = handle;
+    const result = await handle.done;
+    this.activeStream = undefined;
+    this.busy = false;
+    if (result.ok && result.artifact) {
+      this.downloadedArtifact = { ...result, ready: true };
+      if (typeof result.family === "string") {
+        this.downloadFamily = result.family;
+      }
+      if (typeof result.port === "string") {
+        this.selection.port = result.port;
+      }
+      this.phase("ready", "Downloaded");
+      this.post({ type: "artifact", artifact: this.downloadedArtifact });
+      if (typeof result.flashOffset === "string" && result.flashOffset) {
+        this.post({
+          type: "flashOffsetDefault",
+          flashOffset: result.flashOffset,
+        });
+      }
+      this.pushState();
+    } else {
+      this.downloadedArtifact = undefined;
+      this.phase("failed", String(result.error || "Download failed"));
+      this.post({ type: "artifact", artifact: { ready: false } });
+    }
+  }
+
+  private async browseArtifact(): Promise<void> {
+    const uris = await vscode.window.showOpenDialog({
+      canSelectFiles: true,
+      canSelectFolders: false,
+      canSelectMany: false,
+      openLabel: "Use firmware file",
+      title: "Select a .bin or .uf2 firmware file",
+      filters: { Firmware: ["bin", "uf2", "hex"] },
+    });
+    if (!uris?.[0]) {
+      return;
+    }
+    const p = uris[0].fsPath;
+    let size = 0;
+    try {
+      size = fs.statSync(p).size;
+    } catch {
+      /* ignore */
+    }
+    this.downloadedArtifact = {
+      ready: true,
+      artifact: p,
+      size,
+      mtime: Date.now() / 1000,
+      source: "local",
+      board: this.selection.board,
+      family: this.downloadFamily,
+      port: this.selection.port,
+    };
+    this.post({ type: "artifact", artifact: this.downloadedArtifact });
+    this.log(`[mpftp] using local firmware ${p}`);
+  }
+
   private async doFlash(
     offset = "",
     baud = "",
@@ -823,11 +1074,20 @@ export class FirmwarePanel {
     after = "",
     erase = false
   ): Promise<void> {
-    if (this.busy || !this.guardMp()) {
+    const downloadMode = this.prefs.firmwareSource === "download";
+    if (this.busy || (!downloadMode && !this.guardMp())) {
+      return;
+    }
+    if (downloadMode && !this.downloadedArtifact?.ready) {
+      void vscode.window.showWarningMessage("Download firmware first (or Browse local…).");
       return;
     }
     const port = this.selection.port;
-    if (!this.flashers[port]) {
+    if (!this.flashers[port] && !downloadMode) {
+      void vscode.window.showWarningMessage(`Flashing is not supported for '${port}'.`);
+      return;
+    }
+    if (downloadMode && !["esp32", "rp2", "samd"].includes(port)) {
       void vscode.window.showWarningMessage(`Flashing is not supported for '${port}'.`);
       return;
     }
@@ -890,13 +1150,21 @@ export class FirmwarePanel {
     }
 
     const esptool = this.engine.esptoolCommand();
+    const artifactPath =
+      downloadMode && typeof this.downloadedArtifact?.artifact === "string"
+        ? String(this.downloadedArtifact.artifact)
+        : undefined;
     const handle = this.engine.stream(
       "flash",
       {
-        ...this.pathArgs(),
+        ...(downloadMode ? {} : this.pathArgs()),
+        // Download mode still passes mp if known (better offset from board.json).
+        ...(downloadMode && this.mpDir() ? { mp: this.mpDir() } : {}),
         port,
         board: this.selection.board,
         variant: this.selection.variant,
+        family: downloadMode ? this.downloadFamily || undefined : undefined,
+        artifact: artifactPath,
         device: flashDevice,
         esptool: esptool || undefined,
         offset: port === "esp32" ? offset || undefined : undefined,
@@ -986,10 +1254,15 @@ export class FirmwarePanel {
     }
     try {
       await this.bridge.ensureStarted();
-      const ports = await this.bridge.listPorts();
+      const ports = filterAndSortPorts(await this.bridge.listPorts(), {
+        lastDevice: this.bridge.lastDevice || this.prefs.device || undefined,
+        lastVidPid: this.bridge.rememberedVidPid,
+      });
       const items = ports.map((p) => ({
         label: p.device,
-        description: p.product || p.description || "",
+        description: [p.product || p.description || "", p.interface || ""]
+          .filter(Boolean)
+          .join(" · "),
       }));
       const manual = { label: "$(edit) Enter manually…", description: "" };
       const pick = await vscode.window.showQuickPick([...items, manual], {

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -252,3 +252,53 @@ export function getConfig() {
     esptoolCommand: cfg.get<string>("esptoolCommand") || "",
   };
 }
+
+/** globalState keys for last successful connect (not user settings). */
+export const GS_LAST_DEVICE = "mpftp.lastDevice";
+export const GS_LAST_VIDPID = "mpftp.lastVidPid";
+
+export type PortPickInfo = {
+  device: string;
+  vid?: number | null;
+  pid?: number | null;
+  repl?: boolean;
+  interface?: string | null;
+  description?: string | null;
+  product?: string | null;
+  manufacturer?: string | null;
+  serial_number?: string | null;
+  hwid?: string | null;
+};
+
+export function portVidPidKey(p: PortPickInfo): string | undefined {
+  if (p.vid == null || p.pid == null) {
+    return undefined;
+  }
+  return `${p.vid}:${p.pid}`;
+}
+
+/** CircuitPython CDC2 and other non-REPL interfaces are marked repl=false. */
+export function isReplPort(p: PortPickInfo): boolean {
+  return p.repl !== false;
+}
+
+/** Drop non-REPL ports and prefer last-good device / VID:PID. */
+export function filterAndSortPorts<T extends PortPickInfo>(
+  ports: T[],
+  opts: { lastDevice?: string; lastVidPid?: string } = {}
+): T[] {
+  const repl = ports.filter(isReplPort);
+  const score = (p: T): number => {
+    if (opts.lastDevice && p.device === opts.lastDevice) {
+      return 0;
+    }
+    const key = portVidPidKey(p);
+    if (opts.lastVidPid && key === opts.lastVidPid) {
+      return 1;
+    }
+    return 2;
+  };
+  return [...repl].sort(
+    (a, b) => score(a) - score(b) || (a.device || "").localeCompare(b.device || "")
+  );
+}

--- a/src/webview/FtpViewProvider.ts
+++ b/src/webview/FtpViewProvider.ts
@@ -14,6 +14,19 @@ function joinRemote(base: string, name: string): string {
   return base.replace(/\/+$/, "") + "/" + name;
 }
 
+/** Short label for tab titles: COM4, ttyACM0 (not the full /dev path). */
+function shortDeviceName(device: string): string {
+  const s = device.trim();
+  if (!s) {
+    return s;
+  }
+  // Windows COM ports stay as-is; Unix device paths → basename.
+  if (s.includes("/") || s.includes("\\")) {
+    return path.basename(s);
+  }
+  return s;
+}
+
 /** Skip VCS/env/bytecode noise: .git, .venv, __pycache__, *.pyc, etc. */
 function shouldSkipTransferEntry(name: string): boolean {
   if (!name || name === "." || name === "..") {
@@ -148,6 +161,7 @@ export class FtpViewProvider implements vscode.WebviewViewProvider {
   ): void {
     this.view = webviewView;
     this.attachWebview(webviewView.webview);
+    this.updateTitles();
     webviewView.onDidDispose(() => {
       this.webviews.delete(webviewView.webview);
       if (this.view === webviewView) {
@@ -170,12 +184,13 @@ export class FtpViewProvider implements vscode.WebviewViewProvider {
   openInEditor(): void {
     if (this.editorPanel) {
       this.editorPanel.reveal(vscode.ViewColumn.Beside);
+      this.updateTitles();
       void this.pushState();
       return;
     }
     this.editorPanel = vscode.window.createWebviewPanel(
       "mpftp.ftpEditor",
-      "mpftp Board Files",
+      this.panelTitle(),
       vscode.ViewColumn.Beside,
       {
         enableScripts: true,
@@ -193,6 +208,22 @@ export class FtpViewProvider implements vscode.WebviewViewProvider {
     });
     this.bindBridgeEvents();
     void this.pushState();
+  }
+
+  /** Editor tab / sidebar title: `mpftp COM4` or `mpftp disconnected`. */
+  private panelTitle(): string {
+    const device = this.bridge.connectedDevice;
+    return device ? `mpftp ${shortDeviceName(device)}` : "mpftp disconnected";
+  }
+
+  private updateTitles(): void {
+    const title = this.panelTitle();
+    if (this.editorPanel) {
+      this.editorPanel.title = title;
+    }
+    if (this.view) {
+      this.view.title = title;
+    }
   }
 
   private attachWebview(webview: vscode.Webview): void {
@@ -217,10 +248,12 @@ export class FtpViewProvider implements vscode.WebviewViewProvider {
     }
     this.bridgeEventsBound = true;
     this.bridge.on("connected", () => {
+      this.updateTitles();
       void this.refreshDeviceInfo().then(() => this.pushState());
     });
     this.bridge.on("disconnected", () => {
       this.deviceInfo = "";
+      this.updateTitles();
       void this.pushState();
     });
   }
@@ -932,7 +965,6 @@ export class FtpViewProvider implements vscode.WebviewViewProvider {
       <button id="btnConnect">Connect</button>
       <button id="btnRepl" class="secondary" disabled>REPL</button>
       <button id="btnFirmware" class="secondary" title="Build & flash firmware">Firmware</button>
-      <span class="status" id="status">Not connected</span>
     </div>
     <div class="panes">
       <section class="pane" id="localPane">


### PR DESCRIPTION
## Summary
- Official MicroPython **Download** path alongside Build (Thonny catalog → micropython.org), including board variants (e.g. P4 `C6_WIFI`) and flash offset from upstream `board.json`
- Connect recovers when esptool left the chip in ROM download mode; Detect hard-resets afterward; esptool v5 hyphenated CLI (`write-flash`, `default-reset`, …)
- Firmware panel steps: Detect → Select → Target → Build/Download → Flash (Modules nested under Select when Build)

## Test plan
- [ ] Download mode: select ESP32_GENERIC_P4 / C6_WIFI, download, confirm flash offset `0x2000`, flash
- [ ] Build mode still works with Modules under Select
- [ ] Detect then Connect without manual RESET
- [ ] Flash log has no esptool deprecation warnings for `--before`/`--after`/`write-flash`