### PR TITLE
Enter the bootloader on CircuitPython; document CircuitPython behaviour for agents

### DIFF
--- a/docs/agent-guide.md
+++ b/docs/agent-guide.md
@@ -136,11 +136,120 @@ a mounted CIRCUITPY drive, or optionally `storage.disable_usb_drive()` in
 
 ---
 
+## CircuitPython specifics
+
+CircuitPython behaves differently enough from MicroPython that assuming parity
+will cost you hours. The differences below were all found the hard way.
+
+### File operations do not interrupt the running program
+
+On a CircuitPython board, `put` / `get` / `ls` / `hash` are routed through the
+mounted `CIRCUITPY` volume instead of the serial port. The response says so:
+
+```bash
+./scripts/mpftp put -d COM59 ./probe.py /probe.py
+# {"path": "/probe.py", "size": 18, "via": "circuitpy_msc"}
+```
+
+This is the single most useful fact for an agent working on CircuitPython. On
+MicroPython, reading a board to see how a long-running script is doing **is what
+kills it** — every `exec` / `get` / `put` enters the raw REPL and Ctrl-Cs
+whatever is running, so you need the write-to-file pattern under *Board
+filesystem & REPL*. On CircuitPython you can just read the file.
+
+Two caveats:
+
+- The volume must actually be mounted. Under WSL, `/mnt/d` will **not** exist —
+  Windows does not auto-mount removable drives into WSL — so the sidecar uses the
+  Windows path (`D:\`) with Windows Python. That is handled for you.
+- The initial `connect` still interrupts once, because the interpreter has to be
+  detected before the routing decision can be made.
+
+`boot_out.txt` on the volume identifies the board without any serial contact, and
+its `UID` equals the port's `serial_number`, so a volume can be matched to a COM
+port offline:
+
+```
+Adafruit CircuitPython 10.2.1 on 2026-08-21; Waveshare RP2040-TOUCH-LCD-1.28
+Board ID:waveshare_rp2040_touch_lcd_1_28
+UID:E462A052C73E4A29
+```
+
+### The board cannot write its own filesystem
+
+While USB MSC is exposed, `CIRCUITPY` is writable by the **host** and read-only
+to the **board**. The MicroPython trick of having a script append progress to
+`/result.txt` does not work here. Use instead:
+
+```python
+import supervisor
+supervisor.get_previous_traceback()   # traceback from the previous code.py run
+```
+
+read from the REPL afterwards — it survives the run that produced it.
+`supervisor.set_next_code_file()` chooses what runs next.
+
+### Do not assume auto-reload
+
+`supervisor.runtime.autoreload` is often **False** (CircuitPython prints
+`Auto-reload is off.` at the top of each run). Writing to the volume then does
+*not* restart the board. Check it rather than relying on a file write to trigger
+a run.
+
+### Entering the bootloader
+
+`mpftp bootloader` picks the right mechanism per interpreter — `machine.bootloader()`
+on MicroPython, `microcontroller.on_next_reset(RunMode.BOOTLOADER)` plus
+`microcontroller.reset()` on CircuitPython — and reports `ok: false` when it could
+not reach the REPL rather than claiming success.
+
+When the board is wedged so badly that Ctrl-C cannot reach the interpreter (see
+below), the REPL path cannot work by definition. On UF2 boards, opening the port
+at **1200 baud with DTR low** enters the bootloader from the USB stack, which
+keeps running when the VM does not:
+
+```python
+import serial, time
+s = serial.Serial("COM59", 1200, timeout=0.3); s.dtr = False
+time.sleep(0.3); s.close()          # board re-enumerates as RPI-RP2
+```
+
+Copy a `.uf2` onto that volume to get back. On RP2040 the `CIRCUITPY`
+filesystem **survives** the reflash — firmware and filesystem are separate
+regions — the same reassurance as flashing ESP32 at `0x2000`.
+
+### Ctrl-C is not an interrupt inside `atexit`
+
+CircuitPython does not arm Ctrl-C as an interrupt character while an `atexit`
+handler runs; it arrives as ordinary stdin data. A handler that loops without
+reading stdin therefore fills the USB CDC receive ring, at which point **host
+writes start timing out** and no tool can reach the board. `connect` hangs, and
+the 1200-baud touch above is the only way back.
+
+If you write board-side code that holds the VM this way, drain the ring each
+pass:
+
+```python
+import sys, supervisor
+rt = supervisor.runtime
+waiting = rt.serial_bytes_available
+if waiting and "\x03" in sys.stdin.read(waiting):
+    ...   # treat as quit
+```
+
+### Firmware building is out of scope
+
+`mpftp firmware *` is MicroPython-only — there is no CircuitPython support in
+`firmware_engine.py` at all. Build CircuitPython with its own toolchain.
+
+---
+
 ## Firmware: diagnose, download, build, flash
 
 Firmware commands are **host-side** and **MicroPython-only**. They do not
 hold the serial lock for the whole build. CircuitPython firmware is out of scope
-for mpftp.
+for mpftp — see [CircuitPython specifics](#circuitpython-specifics), which also
+covers entering the bootloader on UF2 boards.
 ### Detect (troubleshooting first step)
 
 Works on a bare board (no MicroPython). Releases a live session briefly if needed.
@@ -214,6 +323,10 @@ Details: [user guide — Autosize](user-guide.md#esp32-partition-autosize).
 | Build: required tree not found | Symlink under firmware workspace or set env (`IDF_PATH`, `EMSDK`, …); Locate… in UI |
 | App partition too small | Let autosize rebuild once, or adjust `esp32_partitions/<board>.csv` |
 | Module missing from firmware | See [aggregator.md](aggregator.md); `firmware cmods` |
+| CircuitPython: every command hangs, serial **writes** time out | Board is wedged with the CDC receive ring full — Ctrl-C cannot reach it. 1200-baud touch with DTR low → UF2 volume → copy firmware. See [CircuitPython specifics](#circuitpython-specifics) |
+| CircuitPython: reading a file killed my running script | It should not — file ops route over the `CIRCUITPY` volume (`"via": "circuitpy_msc"`). If you see raw-REPL behaviour instead, the volume is not mounted |
+| CircuitPython: wrote to the volume, board did not restart | `supervisor.runtime.autoreload` is likely False; reset explicitly instead |
+| CircuitPython: display blanks the moment the script ends | Expected — the supervisor runs `reset_port()` when the VM finishes, releasing pins and resetting the panel. The app has to hold the VM |
 
 ---
 

--- a/python/sidecar.py
+++ b/python/sidecar.py
@@ -1667,8 +1667,30 @@ print(repr(_out))
                 "note": "device resetting; reconnect required",
             }
 
+    # Entering the bootloader is interpreter-specific. MicroPython exposes
+    # machine.bootloader(); CircuitPython has no machine module at all and arms
+    # the mode for the next reset instead. Sending the MicroPython form to a
+    # CircuitPython board raises ImportError inside exec_raw_no_follow, whose
+    # result is never read -- so the board stayed put while the caller was told
+    # it had worked.
+    _BOOTLOADER_CODE = {
+        "micropython": "import time, machine; time.sleep_ms(100); machine.bootloader()",
+        "circuitpython": (
+            "import time, microcontroller; time.sleep(0.1); "
+            "microcontroller.on_next_reset(microcontroller.RunMode.BOOTLOADER); "
+            "microcontroller.reset()"
+        ),
+    }
+
     def bootloader(self) -> dict[str, Any]:
-        code = "import time, machine; time.sleep_ms(100); machine.bootloader()"
+        interpreter = (self.interpreter or "").lower()
+        code = self._BOOTLOADER_CODE.get(interpreter)
+        if code is None:
+            return {
+                "ok": False,
+                "error": "cannot enter bootloader: interpreter is %r" % (interpreter or None),
+                "hint": "connect first so the interpreter is detected",
+            }
         with self._lock:
             t = self._require()
             self._stop_repl_reader()
@@ -1677,15 +1699,38 @@ print(repr(_out))
             except Exception:
                 pass
             t = self.transport
+            sent = False
+            error: Optional[str] = None
             try:
                 if t is not None:
                     if not t.in_raw_repl:
                         t.enter_raw_repl(soft_reset=False, timeout_overall=5)
                     t.exec_raw_no_follow(code.encode())
-            except Exception:
-                pass
+                    sent = True
+                else:
+                    error = "no transport"
+            except Exception as exc:
+                error = "%s: %s" % (type(exc).__name__, exc)
             self._force_close_transport(graceful=False)
-            return {"ok": True}
+            if not sent:
+                return {
+                    "ok": False,
+                    "interpreter": interpreter,
+                    "error": error or "could not reach the REPL",
+                    "hint": (
+                        "a board busy in a tight loop may not accept Ctrl-C; on UF2 boards "
+                        "opening the port at 1200 baud with DTR low enters the bootloader "
+                        "from the USB stack instead"
+                    ),
+                }
+            return {
+                "ok": True,
+                "interpreter": interpreter,
+                "note": (
+                    "device resetting into the bootloader; it re-enumerates as a UF2 "
+                    "volume (CIRCUITPY disappears on CircuitPython boards)"
+                ),
+            }
 
     def rtc_get(self) -> dict[str, Any]:
         def op(t):

--- a/python/tests/test_circuitpython.py
+++ b/python/tests/test_circuitpython.py
@@ -119,3 +119,36 @@ class CircuitPythonHelperTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class BootloaderCodeTests(unittest.TestCase):
+    """``machine.bootloader()`` does not exist on CircuitPython.
+
+    The MicroPython form used to be sent unconditionally. It is dispatched with
+    ``exec_raw_no_follow``, whose result is never read, and the surrounding
+    ``except`` swallowed the ImportError -- so the board stayed exactly where it
+    was while the caller was told ``{"ok": true}``. Entering the bootloader is
+    the gateway to every reflash, which made that silence expensive.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        cls.codes = _load_sidecar().Session._BOOTLOADER_CODE
+
+    def test_micropython_uses_machine_bootloader(self):
+        code = self.codes["micropython"]
+        self.assertIn("machine.bootloader()", code)
+
+    def test_circuitpython_never_touches_machine(self):
+        code = self.codes["circuitpython"]
+        self.assertNotIn("machine", code)
+        self.assertIn("microcontroller.on_next_reset", code)
+        self.assertIn("RunMode.BOOTLOADER", code)
+        # Arming the mode does nothing on its own; the reset is what applies it.
+        self.assertIn("microcontroller.reset()", code)
+
+    def test_unknown_interpreter_has_no_entry(self):
+        # bootloader() reports ok:false for anything not in this table rather
+        # than guessing at a mechanism.
+        self.assertNotIn("", self.codes)
+        self.assertEqual({"micropython", "circuitpython"}, set(self.codes))


### PR DESCRIPTION
Found while driving a Waveshare RP2040-Touch-LCD-1.28 from a Claude Code session. Follows up [#6](https://github.com/PyDevices/mpftp/issues/6).

## `bootloader` was a silent no-op on CircuitPython

```python
code = "import time, machine; time.sleep_ms(100); machine.bootloader()"
```

CircuitPython has no `machine` module. The code goes out through `exec_raw_no_follow` (result never read), a bare `except` swallowed the `ImportError`, and the method returned `{"ok": true}` regardless. The board never moved.

That silence is expensive because entering the bootloader is the gateway to every reflash — I trusted the response and lost time before checking the board instead.

Now:

- code is chosen per interpreter (`microcontroller.on_next_reset(RunMode.BOOTLOADER)` + `microcontroller.reset()` on CircuitPython)
- an unknown interpreter is **refused**, not guessed at
- failing to reach the REPL returns `ok: false` with the 1200-baud touch as a hint — the case that matters most, since a board wedged badly enough to need the bootloader often cannot answer Ctrl-C

## `docs/agent-guide.md`: CircuitPython specifics

Most of this section documents behaviour that **already works** and is undiscoverable without reading `sidecar.py`:

- **File operations do not interrupt the running program.** `put`/`get`/`ls`/`hash` route through the mounted `CIRCUITPY` volume (`"via": "circuitpy_msc"`). This *inverts* the write-to-file pattern the guide recommends for MicroPython, where reading a board is what kills the script. It is the single most useful fact for an agent on CircuitPython, and it is currently invisible.
- `boot_out.txt`'s `UID` equals the port's `serial_number`, so a volume can be matched to a COM port with no serial contact.
- The board **cannot write its own filesystem** while USB MSC is mounted — use `supervisor.get_previous_traceback()` rather than a progress file.
- `supervisor.runtime.autoreload` is often False; writing to the volume does not restart the board.
- The supervisor runs `reset_port()` when the VM finishes, so a display dies with the script.
- **Ctrl-C is not armed as an interrupt inside `atexit`.** A loop that does not drain the CDC receive ring fills it, host writes start timing out, and no tool can reach the board — only a 1200-baud touch recovers it.

Plus four troubleshooting-playbook rows for those failure modes.

## Verification

- 88 tests pass (was 85).
- On hardware: `mpftp bootloader` re-enumerates the board as `RPI-RP2`, and copying `firmware.uf2` restores it with the `CIRCUITPY` filesystem intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)